### PR TITLE
Script modifications to make things easier to start/stop

### DIFF
--- a/scripts/seafile.sh
+++ b/scripts/seafile.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 
-echo ""
+# $Id: seafile, v 1.6.0 2013-05-01 03:12:59 john Exp $
+
+# seafile combined init job
+
+### BEGIN INIT INFO
+# Provides:          seafile
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs
+# Default-Start:     1 2 3 4 5
+# Default-Stop:
+# Short-Description: Starts Seafile
+# Description: seafile file syncronization service
+### END INIT INFO
+
+
+# To use this, simply link this file to /etc/init.d/seafile
+#   i.e "ln -s /var/www/seafile/seafile.sh /etc/init.d/seafile
+# And then insert it into the init.d configuration
+#   for Ubuntu/Debian, "update-rc.d seafile defaults"
+#
+# The program will run as the user owning this script. For Ubuntu/Debian
+#   it is advisable to have the directory owned by "www-data"
 
 SCRIPT=$(readlink -f "$0")
 INSTALLPATH=$(dirname "${SCRIPT}")
 TOPDIR=$(dirname "${INSTALLPATH}")
 default_ccnet_conf_dir=${TOPDIR}/ccnet
 ccnet_pidfile=${INSTALLPATH}/runtime/ccnet.pid
+runas=$(stat -c %U ${0//.\//})
 
 export PATH=${INSTALLPATH}/seafile/bin:$PATH
 export SEAFILE_LD_LIBRARY_PATH=${INSTALLPATH}/seafile/lib/:${INSTALLPATH}/seafile/lib64:${LD_LIBRARY_PATH}
@@ -48,7 +70,7 @@ function read_seafile_data_dir () {
     fi
 }
 
-function validate_alreay_running () {
+function validate_already_running () {
     if pgrep -f "seafile-controller -c ${default_ccnet_conf_dir}" 2>/dev/null 1>&2; then
         echo "Seafile server already running."
         exit 1;
@@ -56,19 +78,23 @@ function validate_alreay_running () {
 }
 
 function start_seafile_server () {
-    validate_alreay_running;
+    validate_already_running;
     validate_ccnet_conf_dir;
     read_seafile_data_dir;
 
     echo "Starting seafile server, please wait ..."
 
     seaf_controller="${INSTALLPATH}/seafile/bin/seafile-controller"
+    httpserver="${INSTALLPATH}/seafile/bin/httpserver"
 
     bin_dir="${INSTALLPATH}/seafile/bin"
 
-    LD_LIBRARY_PATH=$SEAFILE_LD_LIBRARY_PATH ${seaf_controller} -c "${default_ccnet_conf_dir}" -d "${seafile_data_dir}"
+    
+    sudo -u ${runas} \
+        LD_LIBRARY_PATH=${SEAFILE_LD_LIBRARY_PATH} \
+            ${seaf_controller} -c "${default_ccnet_conf_dir}" -d "${seafile_data_dir}"
 
-    sleep 3
+    sleep 10
 
     # check if seafile server started successfully
     if ! pgrep -f "seafile-controller -c ${default_ccnet_conf_dir}" 2>/dev/null 1>&2; then
@@ -78,6 +104,22 @@ function start_seafile_server () {
 
     echo "Seafile server started"
     echo
+
+    echo "Starting seafile httpserver, please wait ..."
+    sudo -u ${runas} \
+        LD_LIBRARY_PATH=$SEAFILE_LD_LIBRARY_PATH \
+           ${httpserver} -c "${default_ccnet_conf_dir}" -d "${seafile_data_dir}"
+
+    sleep 2
+    # Check if httpserver started successfully
+    if ! pgrep -f "httpserver -c ${default_ccnet_conf_dir}" 2>/dev/null 1>&2; then
+        echo "Failed to start httpserver server"
+        # Since we have seaf-server started, kill it on failure
+        pkill -SIGTERM -f "seafile-controller -c ${default_ccnet_conf_dir}"
+        exit 1;
+    fi
+
+    echo "Seafile httpserver started"
 }
 
 function stop_seafile_server () {
@@ -88,6 +130,7 @@ function stop_seafile_server () {
 
     echo "Stopping seafile server ..."
     pkill -SIGTERM -f "seafile-controller -c ${default_ccnet_conf_dir}"
+    pkill -f "httpserver -c ${default_ccnet_conf_dir}"
     return 0
 }
 
@@ -97,11 +140,21 @@ function restart_seafile_server () {
     start_seafile_server;
 }
 
+manage_py=${INSTALLPATH}/seahub/manage.py
+function check_seahub_running () {
+    if pgrep -f "${manage_py}" 2>/dev/null 1>&2; then
+        echo "Seahub is running, please stop it before stop seafile."
+        printf "You can stop it by \"\033[33m./seahub.sh stop\033[m\"\n\n"
+        exit 1;
+    fi
+}
+
 case $1 in
     "start" )
         start_seafile_server;
         ;;
     "stop" )
+        check_seahub_running;
         stop_seafile_server;
         ;;
     "restart" )


### PR DESCRIPTION
1. The scripts will run as the user who owns the file. For example,
   if the file is owned by "www-data" it will run as that user
   if executed as root.
2. The script has init.d headers. On Ubuntu/Debian, it one can
   link to the file in /etc/init.d and then run:
       "update-rc.d install <NAME> defaults"
   This makes it really easy to ensure that seafiles starts and
   stops. Tested on Ubuntu 12.04 and Debian (Rasberry Pi)
