### PR TITLE
Fix FILE leak if an error happens while writing pidfile.

### DIFF
--- a/server/seaf-server.c
+++ b/server/seaf-server.c
@@ -718,6 +718,7 @@ write_pidfile (const char *pidfile_path)
     if (fputs(buf, pidfile) < 0) {
         seaf_warning ("Failed to write pidfile %s: %s\n",
                       pidfile_path, strerror(errno));
+        flocse (pidfile);
         return -1;
     }
 


### PR DESCRIPTION
Call fclose() even if writing to the PID file failed, otherwise it was simply leaked in this case.
