### PR TITLE
build-msi.py: Fix evaluation of PKG_CONFIG_PATH

### DIFF
--- a/scripts/build/build-msi.py
+++ b/scripts/build/build-msi.py
@@ -548,7 +548,8 @@ def setup_build_env():
                       seperator=';')
 
     prepend_env_value('PKG_CONFIG_PATH',
-                      os.path.join(prefix, 'lib', 'pkgconfig'))
+                      os.path.join(prefix, 'lib', 'pkgconfig'),
+                      seperator=';')
                       # to_mingw_path(os.path.join(prefix, 'lib', 'pkgconfig')))
 
     # specifiy the directory for wix temporary files


### PR DESCRIPTION
Hey guys! Currently I try to compile a Windows build using your build-msi.py script. In my build-system the PKG_CONFIG_PATH environment variable is already set. Appending a new path-element will fail.

_Sorry for my my double requests_. I want to separate all the pull-requests. That's why I closed the first one again.
