### PR TITLE
MinGW: Fix compilation error of seafile-applet

### DIFF
--- a/gui/win/Makefile
+++ b/gui/win/Makefile
@@ -18,7 +18,7 @@ CFLAGS += -I$(top_srcdir) \
 
 LDFLAGS += -L${top_srcdir}/lib/.libs/   \
 	-lseafile -lseafile_common -lccnet\
-	-lcrypto -lgdi32 -levent  \
+	-lcrypto -lgdi32 -levent -ljansson \
 	-lRpcrt4 -lpthread -lws2_32 -lpsapi -lshlwapi \
 	$(GLIB_LDFLAGS)
 


### PR DESCRIPTION
Hi again! :)

Finally I cannot compile seafile-applet.exe because the jansson-library is not linked against the binary.

```
gcc -o "seafile-applet.exe" seafile-applet.o trayicon.o init-ccnet.o  opendir-proc.o ccnet-init.o applet-log.o rpc-wrapper.o applet-common.o applet-rpc-service.o translate-commit-desc.o resource.o -L/c/seafile-msi-build/usr/lib -LC:/MinGW/msys/1.0/lib -LC:/MinGW/msys/1.0/local/lib -L../../lib/.libs/ -lseafile -lseafile_common -lccnet -lcrypto -lgdi32 -levent -lRpcrt4 -lpthread -lws2_32 -lpsapi -lshlwapi -Lc:/seafile-msi-build/usr/lib -Lc:/gtk+/lib -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lintl  -lcomctl32 -lcomdlg32 -Wl,--subsystem,windows
applet-rpc-service.o: In function `json_array_get_string_or_null_element':
c:/seafile-msi-build/usr/include/searpc-utils.h:41: undefined reference to `json_array_get'
c:/seafile-msi-build/usr/include/searpc-utils.h:43: undefined reference to `json_string_value'
applet-rpc-service.o: In function `json_array_get_int_element':
c:/seafile-msi-build/usr/include/searpc-utils.h:58: undefined reference to `json_array_get'
c:/seafile-msi-build/usr/include/searpc-utils.h:58: undefined reference to `json_integer_value'
applet-rpc-service.o: In function `marshal_int__void':
c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc-marshal.h:9: undefined reference to `json_object'
applet-rpc-service.o: In function `marshal_int__int':
c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc-marshal.h:23: undefined reference to `json_object'
applet-rpc-service.o: In function `marshal_int__int_int':
c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc-marshal.h:38: undefined reference to `json_object'
applet-rpc-service.o: In function `marshal_int__int_string':
c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc-marshal.h:53: undefined reference to `json_object'
applet-rpc-service.o: In function `marshal_int__int_string_int':
c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc-marshal.h:69: undefined reference to `json_object'
applet-rpc-service.o:c:\seafile-msi-build\seafile-2.0.2\gui\win/../../lib/searpc
-marshal.h:85: more undefined references to `json_object' follow../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_get_string_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1777: undefined reference to `json_object_get'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_has_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1786: undefined reference to `json_object_get'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_get_int_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1792: undefined reference to `json_object_get'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_set_string_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1799: undefined reference to `json_string'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_set_int_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1805: undefined reference to `json_integer'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_get_string_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1780: undefined reference to `json_string_value'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_get_int_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1793: undefined reference to `json_integer_value'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_set_string_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1799: undefined reference to `json_object_set_new'
../../lib/.libs//libseafile_common.a(utils.o): In function `json_object_set_int_member':
c:\seafile-msi-build\seafile-2.0.2\lib/utils.c:1805: undefined reference to `json_object_set_new'
collect2.exe: error: ld returned 1 exit status
```

On the other hand: why to compile the old-fashioned client when compiling the v2-version?
