### PR TITLE
Seafile-server support on Mac OS X: Checking for the existence of a process ID by sending signal 0.

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -245,13 +245,14 @@ need_restart (int which)
         seaf_warning ("failed to read pidfile %s: %s\n", ctl->pidfile[which], strerror(errno));
         return FALSE;
     } else {
-        char buf[256];
-        snprintf (buf, sizeof(buf), "/proc/%d", pid);
-        if (g_file_test (buf, G_FILE_TEST_IS_DIR)) {
-            return FALSE;
-        } else {
-            return TRUE;
-        }
+    	if (kill(pid, 0) == 0) {
+    		return FALSE;
+    	} else if (errno == ESRCH) {
+    		return TRUE;
+    	} else {
+            seaf_warning ("failed to send sig 0 to process %d: %s\n", pid, strerror(errno)) ;
+    		return TRUE;
+    	}
     }
 }
 

--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -245,14 +245,14 @@ need_restart (int which)
         seaf_warning ("failed to read pidfile %s: %s\n", ctl->pidfile[which], strerror(errno));
         return FALSE;
     } else {
-    	if (kill(pid, 0) == 0) {
-    		return FALSE;
-    	} else if (errno == ESRCH) {
-    		return TRUE;
-    	} else {
+        if (kill(pid, 0) == 0) {
+            return FALSE;
+        } else if (errno == ESRCH) {
+            return TRUE;
+        } else {
             seaf_warning ("failed to send sig 0 to process %d: %s\n", pid, strerror(errno)) ;
-    		return TRUE;
-    	}
+            return TRUE;
+        }
     }
 }
 


### PR DESCRIPTION
In order to improve support of Seafile-server on Mac OS X I suggest checking for the existence of a process ID by sending signal 0 instead of testing process directory in /proc filesystem, because there is no /proc filesystem on Mac OS X.
