### PR TITLE
removed duplicate definitions

### DIFF
--- a/fuse/file.c
+++ b/fuse/file.c
@@ -13,7 +13,6 @@
 #include "utils.h"
 
 #include "seaf-fuse.h"
-#include "seafile-session.h"
 
 int read_file(SeafileSession *seaf, Seafile *file, char *buf, size_t size,
               off_t offset, struct fuse_file_info *info)

--- a/fuse/seaf-fuse.c
+++ b/fuse/seaf-fuse.c
@@ -16,7 +16,6 @@
 #include "log.h"
 #include "utils.h"
 
-#include "seafile-session.h"
 #include "seaf-fuse.h"
 
 CcnetClient *ccnet_client = NULL;

--- a/fuse/seaf-fuse.h
+++ b/fuse/seaf-fuse.h
@@ -1,8 +1,7 @@
 #ifndef SEAF_FUSE_H
 #define SEAF_FUSE_H
 
-typedef struct _SeafileSession SeafileSession;
-typedef struct _Seafile Seafile;
+#include "seafile-session.h"
 
 int parse_fuse_path (const char *path,
                      int *n_parts, char **user, char **repo_id, char **repo_path);


### PR DESCRIPTION
while trying to build with build-server.py using centos 6.5 and  gcc 4.4.7 I got duplicate definitions errors. 
This pull-request fixes this behavior.
