### PR TITLE
Resolve realloc mistake and possible NP dereferences in lib/utils.c

### DIFF
--- a/lib/utils.c
+++ b/lib/utils.c
@@ -674,11 +674,16 @@ char** strsplit_by_space (char *string, int *length)
     char **array;
     
     if (string == NULL || string[0] == '\0') {
-        *length = 0;
+        if (length != NULL) {
+          *length = 0;
+        }
         return NULL;
     }
 
     array = malloc (sizeof(char *) * size);
+    if (array == NULL) {
+      return NULL;
+    }
     
     remainder = string;
     while (!done) {
@@ -692,13 +697,21 @@ char** strsplit_by_space (char *string, int *length)
         array[num++] = remainder;
         if (!done && num == size) {
             size <<= 1;
-            array = realloc (array, sizeof(char *) * size);
+            char** tmp = realloc (array, sizeof(char *) * size);
+            if (tmp == NULL) {
+              free(array);
+              return NULL;
+            }
+            array = tmp;
         }
 
         remainder = s + 1;
     }
     
-    *length = num;
+    if (length != NULL) {
+      *length = num;
+    }
+
     return array;
 }
 
@@ -714,6 +727,9 @@ char** strsplit_by_char (char *string, int *length, char c)
     }
 
     array = malloc (sizeof(char *) * size);
+    if (array == NULL) {
+      return NULL;
+    }
     
     remainder = string;
     while (!done) {
@@ -727,13 +743,21 @@ char** strsplit_by_char (char *string, int *length, char c)
         array[num++] = remainder;
         if (!done && num == size) {
             size <<= 1;
-            array = realloc (array, sizeof(char *) * size);
+            char** tmp = realloc (array, sizeof(char *) * size);
+            if (tmp == NULL) {
+              free(array);
+              return NULL;
+            }
+            array = tmp;
         }
 
         remainder = s + 1;
     }
     
-    *length = num;
+    if (length != NULL) {
+      *length = num;
+    }
+
     return array;
 }
 


### PR DESCRIPTION
This patches resolves the following issues in lib/utils/strsplit_by_space and in
lib/utils/strsplit_by_char:
- Check if the pointer to the passed length parameter is valid
  otherwise it will cause a NULL pointer dereference
- If the allocation done by realloc fails the current code would
  overwrite the pointer to the previously allocated memory with NULL, thus it is
  not reachable anymore. Therefore we need to store the return value of realloc
  in a temporary variable and then check it if the realloc call has succeeded or
  not. On failure we free the previously allocated memory and return an error.
