### PR TITLE
Fix the problem of DESTDIR and libtool for libccnet.la

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,9 @@ build:
 	# build and install ccnet so it can be used by seafile
 	cd $(ccnet_dir) && ./configure $(CROSS) --prefix=/usr --disable-compile-demo CFLAGS="$(CFLAGS)" && make && make install DESTDIR=$(destdir)
 
+	# Fix the problem of DESTDIR and libtool
+	sed -i -e "s;/usr/lib/libsearpc.la;$(destdir)/usr/lib/libsearpc.la;g" $(install_prefix)/lib/libccnet.la
+
 	./configure --prefix=/usr CFLAGS="$(CFLAGS)" && make && make install DESTDIR=$(destdir)
 
 	# build and install seafile-client


### PR DESCRIPTION
build on a clean and fresh ubuntu 12.04 will fail without this fix.
