### PR TITLE
Allow version with suffix in build scripts

### DIFF
--- a/scripts/build/build-cli.py
+++ b/scripts/build/build-cli.py
@@ -285,7 +285,7 @@ def validate_args(usage, options):
     # [ version ]
     def check_project_version(version):
         '''A valid version must be like 1.2.2, 1.3'''
-        if not re.match('^[0-9](\.[0-9])+$', version):
+        if not re.match('^[0-9](\.[0-9])+((-[a-z]+)?)$', version):
             error('%s is not a valid version' % version, usage=usage)
 
     version = get_option(CONF_VERSION)

--- a/scripts/build/build-deb.py
+++ b/scripts/build/build-deb.py
@@ -280,7 +280,7 @@ def validate_args(usage, options):
     # [ version ]
     def check_project_version(version):
         '''A valid version must be like 1.2.2, 1.3'''
-        if not re.match('^[0-9](\.[0-9])+$', version):
+        if not re.match('^[0-9](\.[0-9])+((-[a-z]+)?)$', version):
             error('%s is not a valid version' % version, usage=usage)
 
     version = get_option(CONF_VERSION)

--- a/scripts/build/build-msi.py
+++ b/scripts/build/build-msi.py
@@ -347,7 +347,7 @@ def validate_args(usage, options):
     # [ version ]
     def check_project_version(version):
         '''A valid version must be like 1.2.2, 1.3'''
-        if not re.match('^[0-9](\.[0-9])+$', version):
+        if not re.match('^[0-9](\.[0-9])+((-[a-z]+)?)$', version):
             error('%s is not a valid version' % version, usage=usage)
 
     version = get_option(CONF_VERSION)

--- a/scripts/build/build-server.py
+++ b/scripts/build/build-server.py
@@ -299,7 +299,7 @@ def validate_args(usage, options):
     # [ version ]
     def check_project_version(version):
         '''A valid version must be like 1.2.2, 1.3'''
-        if not re.match('^[0-9](\.[0-9])+$', version):
+        if not re.match('^[0-9](\.[0-9])+((-[a-z]+)?)$', version):
             error('%s is not a valid version' % version, usage=usage)
 
     version = get_option(CONF_VERSION)


### PR DESCRIPTION
I think it is useful to allow setting a version suffix like 2.1.3-testing to the build scripts.
This change was tested with:
* Windows MinGW 4.4.0 and QT 4.8
* Ubuntu 12.04 i386 and amd64
* Mac OS with latest xcode under 10.8 and 10.9
