### PR TITLE
Enable log rotation

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -11,48 +11,109 @@
 /* message with greater log levels will be ignored */
 static int ccnet_log_level;
 static int seafile_log_level;
+static int seafile_log_options = 0;
+static char logf_path[PATH_MAX];
 static FILE *logfp;
 
-static void 
+/* Maximum size of a logfile (in bytes), default is 5MB */
+#ifndef MAX_LOG_SIZE
+#define MAX_LOG_SIZE 1024 * 1024 * 5
+#endif
+
+/* Maximum number of logfiles */
+#ifndef MAX_LOG_NUM
+#define MAX_LOG_NUM 10
+#endif
+
+static void
+rotate_log()
+{
+    int i, rc;
+    char fn_new[PATH_MAX];
+
+    long fpos = ftell(logfp);
+    g_return_if_fail (fpos >= 0);
+
+    if (fpos < MAX_LOG_SIZE) {
+        /* Nothing to do, size not exceeded maximumm size */
+        return;
+    }
+
+    fclose(logfp);
+
+    /* Rename logfiles: <filename>.<num> to <filename.<num + 1>
+       Last logfile will be removed */
+    for (i = MAX_LOG_NUM - 1; i >= 0; i--) {
+        char fn_old[PATH_MAX];
+
+        snprintf(fn_old, sizeof(fn_old), "%s.%i", logf_path, i);
+
+        if (i < MAX_LOG_NUM - 1) {
+            /* Move logfile */
+
+            snprintf(fn_new, sizeof(fn_new), "%s.%i", logf_path, i + 1);
+            rc = rename(fn_old, fn_new);
+        } else {
+            /* The last logfile will be removed */
+            rc = unlink(fn_old);
+        }
+
+        if (rc == -1 && errno != ENOENT) {
+            /* Do not log on error here, simply write to stderr and continue */
+            perror(__FUNCTION__);
+        }
+    }
+
+    /* Move current logfile from <filename> to <filename>.0 */
+    snprintf(fn_new, sizeof(fn_new), "%s.0", logf_path);
+    rc = rename(logf_path, fn_new);
+    if (rc == -1) {
+        perror(__FUNCTION__);
+        abort(); /* This is a serious error! */
+    }
+
+    /* Re-open logfile */
+    if ((logfp = fopen(logf_path, "a+")) == NULL) {
+        perror(__FUNCTION__);
+        abort();
+    }
+}
+
+static void
+do_log (GLogLevelFlags log_level, int log_max_level, const gchar *message)
+{
+    time_t t;
+    struct tm *tm;
+    char buf[1024];
+    int len;
+
+    if (log_level > log_max_level)
+        return;
+
+    t = time(NULL);
+    tm = localtime(&t);
+    len = strftime (buf, 1024, "[%x %X] ", tm);
+    g_return_if_fail (len < 1024);
+    fputs (buf, logfp);
+    fputs (message, logfp);
+    fflush (logfp);
+
+    if ((seafile_log_options & SEAFILE_LOG_ROTATE) > 0 && *logf_path != '\0')
+        rotate_log();
+}
+
+static void
 seafile_log (const gchar *log_domain, GLogLevelFlags log_level,
              const gchar *message,    gpointer user_data)
 {
-    time_t t;
-    struct tm *tm;
-    char buf[1024];
-    int len;
-
-    if (log_level > seafile_log_level)
-        return;
-
-    t = time(NULL);
-    tm = localtime(&t);
-    len = strftime (buf, 1024, "[%x %X] ", tm);
-    g_return_if_fail (len < 1024);
-    fputs (buf, logfp);
-    fputs (message, logfp);
-    fflush (logfp);
+    do_log(log_level, seafile_log_level, message);
 }
 
-static void 
+static void
 ccnet_log (const gchar *log_domain, GLogLevelFlags log_level,
              const gchar *message,    gpointer user_data)
 {
-    time_t t;
-    struct tm *tm;
-    char buf[1024];
-    int len;
-
-    if (log_level > ccnet_log_level)
-        return;
-
-    t = time(NULL);
-    tm = localtime(&t);
-    len = strftime (buf, 1024, "[%x %X] ", tm);
-    g_return_if_fail (len < 1024);
-    fputs (buf, logfp);
-    fputs (message, logfp);
-    fflush (logfp);
+    do_log(log_level, ccnet_log_level, message);
 }
 
 static int
@@ -80,9 +141,13 @@ seafile_log_init (const char *logfile, const char *ccnet_debug_level_str,
     ccnet_log_level = get_debug_level(ccnet_debug_level_str, G_LOG_LEVEL_INFO);
     seafile_log_level = get_debug_level(seafile_debug_level_str, G_LOG_LEVEL_DEBUG);
 
-    if (strcmp(logfile, "-") == 0)
+    strncpy(logf_path, logfile, PATH_MAX - 1);
+    logf_path[PATH_MAX - 1] = '\0';
+
+    if (strcmp(logfile, "-") == 0) {
         logfp = stdout;
-    else {
+        *logf_path = '\0';
+    } else {
         logfile = ccnet_expand_path(logfile);
         if ((logfp = g_fopen (logfile, "a+")) == NULL) {
             return -1;
@@ -92,6 +157,9 @@ seafile_log_init (const char *logfile, const char *ccnet_debug_level_str,
     return 0;
 }
 
+int seafile_log_set_option(SeafileLogOption options) {
+    seafile_log_options |= options;
+}
 
 static SeafileDebugFlags debug_flags = 0;
 

--- a/common/log.h
+++ b/common/log.h
@@ -15,6 +15,12 @@
 int seafile_log_init (const char *logfile, const char *ccnet_debug_level_str,
                       const char *seafile_debug_level_str);
 
+typedef enum {
+  SEAFILE_LOG_ROTATE = 0x1
+} SeafileLogOption;
+
+int seafile_log_set_option(SeafileLogOption options);
+
 void
 seafile_debug_set_flags_string (const gchar *flags_string);
 

--- a/daemon/seaf-daemon.c
+++ b/daemon/seaf-daemon.c
@@ -46,7 +46,7 @@ SearpcClient *ccnetrpc_client;
 SearpcClient *appletrpc_client;
 CcnetClient *bind_client;
 
-static const char *short_options = "hvc:d:w:l:D:bg:G:";
+static const char *short_options = "hvc:d:w:l:D:bg:G:R";
 static struct option long_options[] = {
     { "help", no_argument, NULL, 'h', },
     { "version", no_argument, NULL, 'v', },
@@ -58,6 +58,7 @@ static struct option long_options[] = {
     { "log", required_argument, NULL, 'l' },
     { "ccnet-debug-level", required_argument, NULL, 'g' },
     { "seafile-debug-level", required_argument, NULL, 'G' },
+    { "log-rotate", no_argument, NULL, 'R' },
     { NULL, 0, NULL, 0, },
 };
 
@@ -398,6 +399,9 @@ main (int argc, char **argv)
             break;
         case 'G':
             seafile_debug_level_str = optarg;
+            break;
+        case 'R':
+            seafile_log_set_option(SEAFILE_LOG_ROTATE);
             break;
         default:
             usage ();


### PR DESCRIPTION
Hey guys!

On client-side there is a serious problem, where the logfiles grows unlimited. We were able to create a seafile.log with a size of >1GB...

I've a patch which implements log rotation for seafile. The max. file size and number of logfiles are specified with the MAX_LOG_SIZE resp. MAX_LOG_NUM macros. Log roration can be enabled with the SEAFILE_LOG_ROTATE option (new seafile_log_set_option function).

Log rotation is only required for the client. The server-platform usually has a logrotate-daemon. That's why I decided to define a "-R" commandline argument for seaf-daemon to enable logfile rotation. Later, the seafile-client has to start the daemon with the "-R" switch.

Could you please review the patch and give me a feedback?

Further steps: Logfile rotation for ccnet (ccnet.log) and seafile-client (applet.log). And (of course) the daemons should be started with the "-R" argument. I can provide the patches as well, but first I want to make sure, you accept the current solution.

Cheers, Robin.
