### PR TITLE
Should not change localhost to '127.0.0.1'

### DIFF
--- a/scripts/setup-seafile-mysql.py
+++ b/scripts/setup-seafile-mysql.py
@@ -401,9 +401,6 @@ Please choose a way to initialize seafile databases:
             if not re.match(r'^[a-zA-Z0-9_\-\.]+$', host):
                 raise InvalidAnswer('%s is not a valid host' % Utils.highlight(host))
 
-            if host == 'localhost':
-                host = '127.0.0.1'
-
             question = 'What is the port of mysql server?'
             key = 'mysql server port'
             default = '3306'


### PR DESCRIPTION
Changing localhost to an IP forces MySQLdb to use a TCP connection, but on unix system, 'localhost' automatically makes MySQLdb use a socket connection which is preferred. If these two odd lines stay, it's impossible to setup a MySQL server with a socket :)

I've tested, and it works simply removing these two. I don't think it should be a problem, if people really wanna use TCP for the local machine, they can still write 127.0.0.1 even though it seems silly.
