### PR TITLE
Add #ifdef to include correct headers on BSD systems

### DIFF
--- a/httpserver/access-file.c
+++ b/httpserver/access-file.c
@@ -3,7 +3,14 @@
 #define DEBUG_FLAG SEAFILE_DEBUG_HTTP
 #include "log.h"
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+#include <event2/bufferevent_struct.h>
+#else
 #include <event.h>
+#endif
+
 #include <evhtp.h>
 
 #include <sys/stat.h>

--- a/httpserver/httpserver.c
+++ b/httpserver/httpserver.c
@@ -5,7 +5,12 @@
 
 #include <getopt.h>
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/event.h>
+#else
 #include <event.h>
+#endif
+
 #include <evhtp.h>
 
 #include <ccnet.h>

--- a/httpserver/upload-file.c
+++ b/httpserver/upload-file.c
@@ -6,7 +6,12 @@
 #include <getopt.h>
 #include <fcntl.h>
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/event.h>
+#else
 #include <event.h>
+#endif
+
 #include <evhtp.h>
 
 #include <jansson.h>

--- a/lib/net.c
+++ b/lib/net.c
@@ -31,7 +31,11 @@
 
 #include <fcntl.h>
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/util.h>
+#else
 #include <evutil.h>
+#endif
 
 #include "net.h"
 

--- a/lib/net.h
+++ b/lib/net.h
@@ -19,7 +19,11 @@
     #include <netinet/tcp.h>
 #endif
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/util.h>
+#else
 #include <evutil.h>
+#endif
 
 #ifdef WIN32
     #define ECONNREFUSED WSAECONNREFUSED

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -11,11 +11,20 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <stdlib.h>
-#include <evutil.h>
 #include <sys/stat.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/util.h>
+#else
+#include <evutil.h>
+#endif
 
 #ifdef __linux__
 #include <endian.h>
+#endif
+
+#ifdef __OpenBSD__
+#include <machine/endian.h>
 #endif
 
 #ifdef WIN32

--- a/server/listen-mgr.c
+++ b/server/listen-mgr.c
@@ -3,6 +3,13 @@
 #include <event2/event.h>
 #include <event2/listener.h>
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <event2/bufferevent.h>
+#include <event2/buffer_compat.h>
+#include <event2/bufferevent_struct.h>
+#endif
+
+
 #include "seafile-session.h"
 #include "utils.h"
 #include "net.h"


### PR DESCRIPTION
Free/Net/OpenBSD have another names for libevent2 headers. Include them conditionally.
