### PR TITLE
fixed typo, purely cosmetic

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -269,21 +269,21 @@ static void
 init_seafile_path ()
 {
     GError *error = NULL;
-    char *exectuble = g_file_read_link ("/proc/self/exe", &error);
+    char *executable = g_file_read_link ("/proc/self/exe", &error);
     char *tmp = NULL;
     if (error != NULL) {
         seaf_warning ("failed to readlink: %s\n", error->message);
         return;
     }
 
-    bin_dir = g_path_get_dirname (exectuble);
+    bin_dir = g_path_get_dirname (executable);
 
     tmp = g_path_get_dirname (bin_dir);
     installpath = g_path_get_dirname (tmp);
 
     topdir = g_path_get_dirname (installpath);
 
-    g_free (exectuble);
+    g_free (executable);
     g_free (tmp);
 }
 
@@ -999,3 +999,8 @@ int main (int argc, char **argv)
     return 0;
 }
 
+
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include ,
+        


### PR DESCRIPTION
"executable" was written as "exectuble"
