### PR TITLE
Update setup-seafile-mysql.sh

### DIFF
--- a/scripts/setup-seafile-mysql.sh
+++ b/scripts/setup-seafile-mysql.sh
@@ -80,10 +80,10 @@ function check_python () {
         hint="\nOn Debian/Ubntu: apt-get install python-simplejson\nOn CentOS/RHEL: yum install python${py26}-simplejson"
         check_python_module simplejson python-simplejson "${hint}"
 
-        hint="\nOn Debian/Ubntu: apt-get install python-imaging\nOn CentOS/RHEL: yum install python${py26}-imaging"
+        hint="\nOn Debian/Ubntu: apt-get install python-imaging\nOn CentOS/RHEL: yum install python-imaging"
         check_python_module PIL python-imaging "${hint}"
 
-        hint='\nOn Debian/Ubuntu:\n\nsudo apt-get install python-mysqldb\n\nOn CentOS/RHEL:\n\nsudo yum install MYSQL-python'
+        hint='\nOn Debian/Ubuntu:\n\nsudo apt-get install python-mysqldb\n\nOn CentOS/RHEL:\n\nsudo yum install MySQL-python'
         check_python_module MySQLdb python-mysqldb "${hint}"
     fi
     echo


### PR DESCRIPTION
CentOS release 6.5 (Final)

___________

Problem 1)

Checking python on this machine ...
  Checking python module: setuptools ... Done.
  Checking python module: python-simplejson ... Done.
  Checking python module: python-imaging ...
 python-imaging  is not installed, Please install it first.
On Debian/Ubntu: apt-get install python-imaging
On CentOS/RHEL: yum install python2.6-imaging
Error occured during setup.
Please fix possible problems and run the script again.

Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Setting up Install Process
No package python2.6-imaging available.
Error: Nothing to do

Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Setting up Install Process
Resolving Dependencies
...
Installed:
  python-imaging.x86_64 0:1.1.6-19.el6
Dependency Installed:
  freetype.x86_64 0:2.3.11-14.el6_3.1                       libjpeg-turbo.x86_64 0:1.2.1-3.el6_5
Complete!

___________

Problem 2)

Default help messages are not OK on Centos

Checking python on this machine ...
  Checking python module: setuptools ... Done.
  Checking python module: python-simplejson ... Done.
  Checking python module: python-imaging ... Done.
  Checking python module: python-mysqldb ...
 python-mysqldb  is not installed, Please install it first.
On Debian/Ubuntu:
sudo apt-get install python-mysqldb
On CentOS/RHEL:
sudo yum install MYSQL-python
Error occured during setup.
Please fix possible problems and run the script again.

Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Setting up Install Process
No package MYSQL-python available.
  * Maybe you meant: MySQL-python
Error: Nothing to do

Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Setting up Install Process
Resolving Dependencies
...
Running Transaction
  Installing : MySQL-python-1.2.3-0.3.c1.1.el6.x86_64                                                              1/1
  Verifying  : MySQL-python-1.2.3-0.3.c1.1.el6.x86_64                                                              1/1
Installed:
  MySQL-python.x86_64 0:1.2.3-0.3.c1.1.el6
Complete!

Checking python on this machine ...
  Checking python module: setuptools ... Done.
  Checking python module: python-simplejson ... Done.
  Checking python module: python-imaging ... Done.
  Checking python module: python-mysqldb ... Done.
-----------------------------------------------------------------
This script will guide you to setup your seafile server using MySQL.
Make sure you have read seafile server manual at
        https://github.com/haiwen/seafile/wiki
Press ENTER to continue
-----------------------------------------------------------------