### PR TITLE
[server] Add cache support for repo

### DIFF
--- a/common/branch-mgr.c
+++ b/common/branch-mgr.c
@@ -30,6 +30,18 @@ seaf_branch_new (const char *name, const char *repo_id, const char *commit_id)
     return branch;
 }
 
+SeafBranch*
+seaf_branch_dup (const SeafBranch *branch)
+{
+    SeafBranch *new_branch;
+    if (!branch) return NULL;
+    new_branch = g_new (SeafBranch, 1);
+    memcpy (new_branch, branch, sizeof(SeafBranch));
+    new_branch->name = g_strdup (branch->name);
+    new_branch->ref = 1;
+    return new_branch;
+}
+
 void
 seaf_branch_free (SeafBranch *branch)
 {
@@ -417,6 +429,8 @@ seaf_branch_manager_test_and_update_branch (SeafBranchManager *mgr,
     seaf_db_trans_close (trans);
 
     on_branch_updated (mgr, branch);
+
+    seaf_repo_manager_expire_item_from_cache (mgr->seaf->repo_mgr, branch->repo_id);
 
     return 0;
 }

--- a/common/branch-mgr.h
+++ b/common/branch-mgr.h
@@ -16,6 +16,7 @@ struct _SeafBranch {
 SeafBranch *seaf_branch_new (const char *name,
                              const char *repo_id,
                              const char *commit_id);
+SeafBranch* seaf_branch_dup (const SeafBranch *branch);
 void seaf_branch_free (SeafBranch *branch);
 void seaf_branch_set_commit (SeafBranch *branch, const char *commit_id);
 

--- a/server/repo-mgr.h
+++ b/server/repo-mgr.h
@@ -62,6 +62,9 @@ gboolean is_repo_id_valid (const char *id);
 SeafRepo* 
 seaf_repo_new (const char *id, const char *name, const char *desc);
 
+SeafRepo*
+seaf_repo_dup(const SeafRepo *repo);
+
 void
 seaf_repo_free (SeafRepo *repo);
 
@@ -123,6 +126,9 @@ int
 seaf_repo_manager_del_repo (SeafRepoManager *mgr,
                             const char *repo_id,
                             gboolean add_deleted_record);
+void
+seaf_repo_manager_expire_item_from_cache (SeafRepoManager *mgr,
+                                          const char *repo_id);
 
 SeafRepo* 
 seaf_repo_manager_get_repo (SeafRepoManager *manager, const gchar *id);

--- a/server/virtual-repo.c
+++ b/server/virtual-repo.c
@@ -478,6 +478,8 @@ set_virtual_repo_base_commit_path (const char *vrepo_id, const char *base_commit
                              "UPDATE VirtualRepo SET base_commit=?, path=? WHERE repo_id=?",
                              3, "string", base_commit_id, "string", new_path,
                              "string", vrepo_id);
+
+    seaf_repo_manager_expire_item_from_cache (seaf->repo_mgr, vrepo_id);
 }
 
 int


### PR DESCRIPTION
Very limited attempt to add cache support for `repo_id` in `server/repo-mgr.c`

Here are some problems known to me:
1. No way to destroy this `GHashTable` (named `cached_repos` in `struct SeafRepoManagerPriv`) since I could not find out where the parent `SeafRepoManagerPriv` instance gets destroyed.
1. Don't want to hack into `repo_exists_in_db`, and it seems less frequently called than `seaf_repo_manager_get_repo`. Maybe it would be good enough to achieve our goal. However, no profiling data is available at the second.
