### PR TITLE
remove related pid file when kill the controlled process among seafile-controller

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -134,8 +134,8 @@ try_kill_process(int which)
     char *pidfile = ctl->pidfile[which];
     int pid = read_pid_from_pidfile(pidfile);
     if (pid > 0) {
-    // if SIGTERM send success, then remove related pid file
-    if (kill ((pid_t)pid, SIGTERM) == 0) {
+        // if SIGTERM send success, then remove related pid file
+        if (kill ((pid_t)pid, SIGTERM) == 0) {
             g_unlink (pidfile);
         }
     }


### PR DESCRIPTION
The change is used to remove related pid file when seafile-controller kill the controlled process
