### PR TITLE
Remove simplejson import

### DIFF
--- a/app/seaf-cli
+++ b/app/seaf-cli
@@ -73,10 +73,7 @@ Create a new library
 
 import argparse
 import os
-try:
-    import json
-except:
-    import simplejson as json
+import json
 import subprocess
 import sys
 import time

--- a/scripts/setup-seafile-mysql.sh
+++ b/scripts/setup-seafile-mysql.sh
@@ -77,9 +77,6 @@ function check_python () {
         hint="\nOn Debian/Ubntu: apt-get install python-setuptools\nOn CentOS/RHEL: yum install python${py26}-distribute"
         check_python_module pkg_resources setuptools "${hint}"
 
-        hint="\nOn Debian/Ubntu: apt-get install python-simplejson\nOn CentOS/RHEL: yum install python${py26}-simplejson"
-        check_python_module simplejson python-simplejson "${hint}"
-
         hint="\nOn Debian/Ubntu: apt-get install python-imaging\nOn CentOS/RHEL: yum install python${py26}-imaging"
         check_python_module PIL python-imaging "${hint}"
 

--- a/scripts/setup-seafile.sh
+++ b/scripts/setup-seafile.sh
@@ -167,8 +167,6 @@ function check_python () {
         fi
         hint="\nOn Debian/Ubntu: apt-get install python-setuptools\nOn CentOS/RHEL: yum install python${py26}-distribute"
         check_python_module pkg_resources setuptools "${hint}"
-        hint="\nOn Debian/Ubntu: apt-get install python-simplejson\nOn CentOS/RHEL: yum install python${py26}-simplejson"
-        check_python_module simplejson python-simplejson "${hint}"
         hint="\nOn Debian/Ubntu: apt-get install python-imaging\nOn CentOS/RHEL: yum install python${py26}-imaging"
         check_python_module PIL python-imaging "${hint}"
         check_python_module sqlite3 python-sqlite3

--- a/tools/seafile-admin
+++ b/tools/seafile-admin
@@ -503,7 +503,6 @@ def check_python_dependencies(silent=False):
 
     if not silent:
         info('check python modules ...')
-    check_python_module('simplejson', 'simplejson', silent=silent)
     check_python_module('sqlite3', 'sqlite3', silent=silent)
     check_python_module('PIL', 'python imaging library(PIL)', silent=silent)
     check_python_module('django', 'django 1.5', silent=silent)


### PR DESCRIPTION
"import json" works in Python >= 2.6. simplejson is only useful for Python <=
2.5, which seafile doesn't seem to be targeting.

The wiki docs also need to be updated if this gets merged.
