### PR TITLE
Check openssl in configure.ac and enable fuse option for mac

### DIFF
--- a/app/Makefile.am
+++ b/app/Makefile.am
@@ -22,7 +22,7 @@ seafile_LDADD =  @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile.la \
 	$(top_builddir)/lib/libseafile_common.la \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 @ZLIB_LIBS@
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @ZLIB_LIBS@
 
 seafile_LDFALGS = @STATIC_COMPILE@ @CONSOLE@
 
@@ -30,7 +30,7 @@ if COMPILE_SERVER
 seafserv_tool_SOURCES = seafserv-tool.c
 seafserv_tool_LDADD =  @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile.la @SEARPC_LIBS@ @JANSSON_LIBS@ \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 @ZLIB_LIBS@
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @ZLIB_LIBS@
 
 seafserv_tool_LDFLAGS = @STATIC_COMPILE@ @CONSOLE@ @SERVER_PKG_RPATH@
 endif
@@ -38,6 +38,6 @@ endif
 # monitor_tool_SOURCES = monitor-tool.c
 # monitor_tool_LDADD = @CCNET_CFLAGS@ \
 # 	-lsearpc \
-# 	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl -lrt -luuid -lsqlite3
+# 	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ -lrt -luuid -lsqlite3
 
 EXTRA_DIST = seaf-cli

--- a/common/cdc/Makefile.am
+++ b/common/cdc/Makefile.am
@@ -8,5 +8,5 @@ noinst_HEADERS = adler32.h  cdc.h  md5.h  rabin.h srabin.h msb.h
 libcdc_la_SOURCES = adler32.c  cdc.c  md5.c  rabin.c srabin.c msb.c
 
 libcdc_la_LDFLAGS = -Wl,-z -Wl,defs
-libcdc_la_LIBADD = -lssl @GLIB2_LIBS@ \
+libcdc_la_LIBADD = @SSL_LIBS@ @GLIB2_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la

--- a/common/index/Makefile.am
+++ b/common/index/Makefile.am
@@ -9,5 +9,5 @@ libindex_la_SOURCES = index.c cache-tree.c
 
 libindex_la_CFLAGS = @GLIB2_CFLAGS@
 libindex_la_LDFLAGS = -Wl,-z -Wl,defs
-libindex_la_LIBADD = -lssl @GLIB2_LIBS@ \
+libindex_la_LIBADD = @SSL_LIBS@ @GLIB2_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la

--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,9 @@ if test "$blinux" = true; then
 
    AC_ARG_ENABLE(riak, AC_HELP_STRING([--enable-riak], [enable riak backend]),
       [compile_riak=$enableval],[compile_riak="no"])
+fi
 
+if test "$bwin32" != true; then
    AC_ARG_ENABLE(fuse, AC_HELP_STRING([--enable-fuse], [enable fuse virtual file system]),
       [compile_fuse=$enableval],[compile_fuse="yes"])
 fi
@@ -241,8 +243,12 @@ JANSSON_REQUIRED=2.2.1
 ZDB_REQUIRED=2.10
 #LIBNAUTILUS_EXTENSION_REQUIRED=2.30.1
 CURL_REQUIRED=7.17
-FUSE_REQUIRED=2.8.6
+FUSE_REQUIRED=2.7.3
 ZLIB_REQUIRED=1.2.0
+
+PKG_CHECK_MODULES(SSL, [openssl])
+AC_SUBST(SSL_CFLAGS)
+AC_SUBST(SSL_LIBS)
 
 PKG_CHECK_MODULES(GLIB2, [glib-2.0 >= $GLIB_REQUIRED])
 AC_SUBST(GLIB2_CFLAGS)

--- a/controller/Makefile.am
+++ b/controller/Makefile.am
@@ -17,7 +17,7 @@ seafile_controller_SOURCES = seafile-controller.c ../common/log.c
 
 seafile_controller_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -levent \
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -levent \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZLIB_LIBS@
 
 seafile_controller_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -122,7 +122,7 @@ seaf_daemon_SOURCES = seaf-daemon.c $(common_src)
 
 seaf_daemon_LDADD = $(top_builddir)/lib/libseafile_common.la \
 	@LIB_INTL@ \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/common/index/libindex.la ${LIB_WS32} \
 	@SEARPC_LIBS@ @CCNET_LIBS@ @GNOME_KEYRING_LIBS@ @JANSSON_LIBS@ @LIB_MAC@ @ZLIB_LIBS@
@@ -176,7 +176,7 @@ seaf_daemon_LDFLAGS = @STATIC_COMPILE@ @CONSOLE@
 #seaf_test_LDADD = @CCNET_LIBS@ \
 #	@LIB_INTL@ \
 #	$(top_builddir)/lib/libseafile_common.la \
-#	@GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+#	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 #	$(top_builddir)/common/cdc/libcdc.la \
 #	$(top_builddir)/common/index/libindex.la ${LIB_WS32} \
 #	@SEARPC_LIBS@ @LIB_DIRWATCH@

--- a/fileserver/Makefile.am
+++ b/fileserver/Makefile.am
@@ -46,7 +46,7 @@ fileserver_SOURCES = \
 	../common/seafile-crypt.c
 
 # XXX: -levent_openssl must be behind in -levhtp
-fileserver_LDADD = -levent -levhtp -lssl -levent_openssl \
+fileserver_LDADD = -levent -levhtp @SSL_LIBS@ -levent_openssl \
 	@GLIB2_LIBS@ @GOBJECT_LIBS@ @LIB_RT@ \
 	@CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile.la \

--- a/fuse/Makefile.am
+++ b/fuse/Makefile.am
@@ -40,7 +40,7 @@ seaf_fuse_SOURCES = seaf-fuse.c \
 
 seaf_fuse_LDADD = @CCNET_LIBS@ \
 				  $(top_builddir)/lib/libseafile.la \
-				  @GLIB2_LIBS@ @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ \
+				  @GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ \
                   -lsqlite3 -levent \
 				  $(top_builddir)/common/cdc/libcdc.la \
 				  @SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @FUSE_LIBS@ @ZLIB_LIBS@

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -53,7 +53,7 @@ noinst_LTLIBRARIES = libseafile_common.la
 
 libseafile_common_la_SOURCES = ${seafile_object_gen} ${utils_srcs}
 libseafile_common_la_LDFLAGS = -no-undefined
-libseafile_common_la_LIBADD = @GLIB2_LIBS@  @GOBJECT_LIBS@ -lssl -lcrypto @LIB_GDI32@ \
+libseafile_common_la_LIBADD = @GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ -lcrypto @LIB_GDI32@ \
 				     @LIB_UUID@ @LIB_WS32@ @LIB_PSAPI@ -lsqlite3 \
 					 -levent @SEARPC_LIBS@ @LIB_SHELL32@ \
 	@ZLIB_LIBS@

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -108,7 +108,7 @@ seaf_server_SOURCES = \
 seaf_server_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
 	$(top_builddir)/common/index/libindex.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 	$(top_builddir)/common/cdc/libcdc.la \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 

--- a/server/gc/Makefile.am
+++ b/server/gc/Makefile.am
@@ -50,7 +50,7 @@ seafserv_gc_SOURCES = \
 seafserv_gc_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seafserv_gc_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@
@@ -63,7 +63,7 @@ seaf_fsck_SOURCES = \
 seaf_fsck_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seaf_fsck_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@
@@ -75,7 +75,7 @@ seaf_migrate_SOURCES = \
 seaf_migrate_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ -lssl @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seaf_migrate_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ test_seafile_fmt_CFLAGS = -I$(top_srcdir)/daemon \
 
 test_seafile_fmt_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
-	-lssl -levent @GLIB2_LIBS@
+	@SSL_LIBS@ -levent @GLIB2_LIBS@
 
 test_cdc_SOURCES = test-cdc.c
 


### PR DESCRIPTION
For mac, I want to assign the openssl used by seafile instead of the one provided by the OS, whose version is to low
