### PR TITLE
remove ignore-error option for seafserv-gc

### DIFF
--- a/server/gc/gc-core.c
+++ b/server/gc/gc-core.c
@@ -356,15 +356,14 @@ out:
 }
 
 int
-gc_core_run (int dry_run, int ignore_errors)
+gc_core_run (int dry_run)
 {
     GList *repos = NULL, *del_repos = NULL, *ptr;
     SeafRepo *repo;
     GList *corrupt_repos = NULL;
     gboolean error = FALSE;
 
-    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1,
-                                             ignore_errors, &error);
+    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1, &error);
     if (error) {
         seaf_warning ("Failed to load repo list.\n");
         return -1;
@@ -384,7 +383,7 @@ gc_core_run (int dry_run, int ignore_errors)
             if (gc_v1_repo (repo, dry_run, FALSE) < 0)
                 corrupt_repos = g_list_prepend (corrupt_repos, g_strdup(repo->id));
         }
-
+        seaf_repo_unref (repo);
     }
     g_list_free (repos);
 
@@ -417,7 +416,9 @@ gc_core_run (int dry_run, int ignore_errors)
         for (ptr = corrupt_repos; ptr; ptr = ptr->next) {
             char *repo_id = ptr->data;
             seaf_message ("%s\n", repo_id);
+            g_free (repo_id);
         }
+        g_list_free (corrupt_repos);
     }
 
     return 0;

--- a/server/gc/gc-core.h
+++ b/server/gc/gc-core.h
@@ -1,6 +1,6 @@
 #ifndef GC_CORE_H
 #define GC_CORE_H
 
-int gc_core_run (int dry_run, int ignore_errors);
+int gc_core_run (int dry_run);
 
 #endif

--- a/server/gc/repo-mgr.c
+++ b/server/gc/repo-mgr.c
@@ -211,6 +211,16 @@ repo_exists_in_db (SeafDB *db, const char *id)
     return seaf_db_check_for_existence (db, sql, &db_err);
 }
 
+static gboolean
+repo_exists_in_db_ex (SeafDB *db, const char *id, gboolean *db_err)
+{
+    char sql[256];
+
+    snprintf (sql, sizeof(sql), "SELECT repo_id FROM Repo WHERE repo_id = '%s'",
+              id);
+    return seaf_db_check_for_existence (db, sql, db_err);
+}
+
 SeafRepo*
 seaf_repo_manager_get_repo (SeafRepoManager *manager, const gchar *id)
 {
@@ -223,7 +233,7 @@ seaf_repo_manager_get_repo (SeafRepoManager *manager, const gchar *id)
     memcpy (repo.id, id, len + 1);
 
     if (repo_exists_in_db (manager->seaf->db, id)) {
-        SeafRepo *ret = load_repo (manager, id);
+        SeafRepo *ret = load_repo (manager, id, FALSE);
         if (!ret)
             return NULL;
         /* seaf_repo_ref (ret); */
@@ -243,7 +253,7 @@ seaf_repo_manager_get_repo_ex (SeafRepoManager *manager, const gchar *id)
     if (len >= 37)
         return NULL;
 
-    exists = repo_exists_in_db (manager->seaf->db, id, &db_err);
+    exists = repo_exists_in_db_ex (manager->seaf->db, id, &db_err);
 
     if (db_err) {
         ret = seaf_repo_new(id, NULL, NULL);
@@ -365,7 +375,6 @@ seaf_repo_manager_get_repo_id_list (SeafRepoManager *mgr)
 GList *
 seaf_repo_manager_get_repo_list (SeafRepoManager *mgr,
                                  int start, int limit,
-                                 gboolean ignore_errors,
                                  gboolean *error)
 {
     char sql[256];

--- a/server/gc/repo-mgr.h
+++ b/server/gc/repo-mgr.h
@@ -111,7 +111,6 @@ seaf_repo_manager_repo_exists (SeafRepoManager *manager, const gchar *id);
 GList* 
 seaf_repo_manager_get_repo_list (SeafRepoManager *mgr,
                                  int start, int limit,
-                                 gboolean ignore_errors,
                                  gboolean *error);
 
 GList *

--- a/server/gc/seaf-migrate.c
+++ b/server/gc/seaf-migrate.c
@@ -303,7 +303,7 @@ migrate_v0_repos_to_v1_layout ()
     SeafRepo *repo;
     gboolean error = FALSE;
 
-    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1, TRUE, &error);
+    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1, &error);
     for (ptr = repos; ptr; ptr = ptr->next) {
         repo = ptr->data;
         if (repo->version == 0)

--- a/server/gc/seafserv-gc.c
+++ b/server/gc/seafserv-gc.c
@@ -25,7 +25,6 @@ static const struct option long_opts[] = {
     { "seafdir", required_argument, NULL, 'd', },
     { "verify", no_argument, NULL, 'V' },
     { "dry-run", no_argument, NULL, 'D' },
-    { "ignore-errors", no_argument, NULL, 'i' },
 };
 
 static void usage ()
@@ -112,9 +111,6 @@ main(int argc, char *argv[])
         case 'D':
             dry_run = 1;
             break;
-        case 'i':
-            ignore_errors = 1;
-            break;
         default:
             usage();
             exit(-1);
@@ -152,7 +148,7 @@ main(int argc, char *argv[])
         return 0;
     }
 
-    gc_core_run (dry_run, ignore_errors);
+    gc_core_run (dry_run);
 
     return 0;
 }

--- a/server/gc/verify.c
+++ b/server/gc/verify.c
@@ -133,7 +133,7 @@ verify_repos ()
     int ret = 0;
     gboolean error = FALSE;
 
-    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1, FALSE, &error);
+    repos = seaf_repo_manager_get_repo_list (seaf->repo_mgr, -1, -1, &error);
     for (ptr = repos; ptr != NULL; ptr = ptr->next) {
         ret = verify_repo ((SeafRepo *)ptr->data);
         seaf_repo_unref ((SeafRepo *)ptr->data);


### PR DESCRIPTION
The modification is based on gc branch, for now ignore-error is the default behavior that is gc will iterate all repos no matter there is a corrupted one, and in the end will list corrupted repo id.
