### PR TITLE
Add option to enable recursion in seafile_diff()

### DIFF
--- a/common/rpc-service.c
+++ b/common/rpc-service.c
@@ -1594,7 +1594,7 @@ get_diff_status_str(char status)
 }
 
 GList *
-seafile_diff (const char *repo_id, const char *arg1, const char *arg2, GError **error)
+seafile_diff (const char *repo_id, const char *arg1, const char *arg2, int fold_dir_diff, GError **error)
 {
     SeafRepo *repo;
     char *err_msgs = NULL;
@@ -1617,7 +1617,7 @@ seafile_diff (const char *repo_id, const char *arg1, const char *arg2, GError **
         return NULL;
     }
 
-    diff_entries = seaf_repo_diff (repo, arg1, arg2, &err_msgs);
+    diff_entries = seaf_repo_diff (repo, arg1, arg2, fold_dir_diff, &err_msgs);
     if (err_msgs) {
         g_set_error (error, SEAFILE_DOMAIN, -1, "%s", err_msgs);
         g_free (err_msgs);

--- a/include/seafile-rpc.h
+++ b/include/seafile-rpc.h
@@ -376,7 +376,7 @@ int seafile_remove_task (const char *task_id, int task_type, GError **error);
  */
 GList *
 seafile_diff (const char *repo_id, const char *old, const char *new,
-              GError **error);
+              int fold_dir_diff, GError **error);
 
 GList *
 seafile_branch_gets (const char *repo_id, GError **error);

--- a/lib/rpc_table.py
+++ b/lib/rpc_table.py
@@ -70,6 +70,7 @@ func_table = [
     [ "objlist", ["string", "string"] ],        
     [ "objlist", ["string", "string", "string"] ],
     [ "objlist", ["string", "string", "int"] ],
+    [ "objlist", ["string", "string", "string", "int"] ],
     [ "objlist", ["string", "string", "int", "int"] ],
     [ "objlist", ["int", "string", "string", "int", "int"] ],
     [ "objlist", ["string", "int", "string", "string", "string"] ],

--- a/python/seafile/rpcclient.py
+++ b/python/seafile/rpcclient.py
@@ -75,7 +75,7 @@ class SeafileRpcClient(ccnet.RpcClientBase):
         pass
     remove_repo = seafile_destroy_repo
 
-    @searpc_func("objlist", ["string", "string", "string"])
+    @searpc_func("objlist", ["string", "string", "string", "int"])
     def seafile_diff():
         pass
     get_diff = seafile_diff

--- a/python/seaserv/api.py
+++ b/python/seaserv/api.py
@@ -82,8 +82,8 @@ class SeafileAPI(object):
     def revert_repo(self, repo_id, commit_id, username):
         return seafserv_threaded_rpc.revert_on_server(repo_id, commit_id, username)
 
-    def diff_commits(self, repo_id, old_commit, new_commit):
-        return seafserv_threaded_rpc.get_diff(repo_id, old_commit, new_commit)
+    def diff_commits(self, repo_id, old_commit, new_commit, fold_dir_diff = 1):
+        return seafserv_threaded_rpc.get_diff(repo_id, old_commit, new_commit, fold_dir_diff)
 
     def get_commit_list(self, repo_id, offset, limit):
         return seafserv_threaded_rpc.get_commit_list(repo_id, offset, limit)

--- a/server/repo-mgr.h
+++ b/server/repo-mgr.h
@@ -92,7 +92,7 @@ GList *
 seaf_repo_get_commits (SeafRepo *repo);
 
 GList *
-seaf_repo_diff (SeafRepo *repo, const char *arg1, const char *arg2, char **error);
+seaf_repo_diff (SeafRepo *repo, const char *arg1, const char *arg2, int fold_dir_diff, char **error);
 
 typedef struct _SeafRepoManager SeafRepoManager;
 typedef struct _SeafRepoManagerPriv SeafRepoManagerPriv;

--- a/server/repo-op.c
+++ b/server/repo-op.c
@@ -4735,7 +4735,7 @@ get_commit(SeafRepo *repo, const char *branch_or_commit)
 }
 
 GList *
-seaf_repo_diff (SeafRepo *repo, const char *old, const char *new, char **error)
+seaf_repo_diff (SeafRepo *repo, const char *old, const char *new, int fold_dir_diff, char **error)
 {
     SeafCommit *c1 = NULL, *c2 = NULL;
     int ret = 0;
@@ -4751,7 +4751,7 @@ seaf_repo_diff (SeafRepo *repo, const char *old, const char *new, char **error)
     
     if (old == NULL || old[0] == '\0') {
         if (c2->parent_id && c2->second_parent_id) {
-            ret = diff_merge (c2, &diff_entries, TRUE);
+            ret = diff_merge (c2, &diff_entries, fold_dir_diff);
             if (ret < 0) {
                 *error = g_strdup("Failed to do diff");
                 seaf_commit_unref (c2);
@@ -4779,7 +4779,7 @@ seaf_repo_diff (SeafRepo *repo, const char *old, const char *new, char **error)
     }
 
     /* do diff */
-    ret = diff_commits (c1, c2, &diff_entries, TRUE);
+    ret = diff_commits (c1, c2, &diff_entries, fold_dir_diff);
     if (ret < 0)
         *error = g_strdup("Failed to do diff");
 

--- a/server/seaf-server.c
+++ b/server/seaf-server.c
@@ -196,7 +196,7 @@ static void start_rpc_service (CcnetClient *client, int cloud_mode)
     searpc_server_register_function ("seafserv-threaded-rpcserver",
                                      seafile_diff,
                                      "seafile_diff",
-                                     searpc_signature_objlist__string_string_string());
+                                     searpc_signature_objlist__string_string_string_int());
 
     searpc_server_register_function ("seafserv-threaded-rpcserver",
                                      seafile_post_file,


### PR DESCRIPTION
It's useful to have an ability to recursively find diffs in repos, I've added a flag to seafile_diff() in order to archive this.
Default value is set, so old code behaves as before.

Right now there isn't way to marshall boolean values, so I use int for that.
How should I proceed with this patch? Should boolean marshalling be added?
