### PR TITLE
Remove new line characters from seafile_data_dir variable

### DIFF
--- a/tools/seafile-admin
+++ b/tools/seafile-admin
@@ -649,7 +649,7 @@ def read_seafile_data_dir(ccnet_conf_dir):
     seafile_ini = os.path.join(ccnet_conf_dir, 'seafile.ini')
     if os.path.exists(seafile_ini):
         with open(seafile_ini, 'r') as fp:
-            seafile_data_dir = fp.read()
+            seafile_data_dir = fp.read().strip()
     else:
         # In previous seafile-admin, seafiled-data folder must be under
         # the top level directory, so we do not store the location of


### PR DESCRIPTION
Remove new line character. Also Python 2.7.8 added a new line character with read() resulting data dir not being recognized as directory.
