### PR TITLE
Improve tmp file ignore

### DIFF
--- a/daemon/repo-mgr.c
+++ b/daemon/repo-mgr.c
@@ -47,10 +47,13 @@ struct _SeafRepoManagerPriv {
 };
 
 static const char *ignore_table[] = {
+    /* tmp files under Linux */
     "*~",
-    "*#",
+    /* Emacs tmp files */
+    "#*#",
     /* ms office tmp files */
     "~$*",
+    "~*.tmp", /* for files like ~WRL0001.tmp */
     /* windows image cache */
     "Thumbs.db",
     /* For Mac */

--- a/server/repo-mgr.c
+++ b/server/repo-mgr.c
@@ -41,12 +41,17 @@ struct _SeafRepoManagerPriv {
 };
 
 static const char *ignore_table[] = {
+    /* tmp files under Linux */
     "*~",
-    "*#",
+    /* Emacs tmp files */
+    "#*#",
     /* ms office tmp files */
     "~$*",
+    "~*.tmp", /* for files like ~WRL0001.tmp */
     /* windows image cache */
     "Thumbs.db",
+    /* For Mac */
+    ".DS_Store",
     NULL,
 };
 


### PR DESCRIPTION
- Do not ignore lock files created by libreoffice
- Ignore temp files created by MSOffice like ~WRL0001.tmp
