### PR TITLE
Don't hardcode -levent in linker flags. Use @LIBEVENT_LIBS@ instead

### DIFF
--- a/controller/Makefile.am
+++ b/controller/Makefile.am
@@ -17,7 +17,7 @@ seafile_controller_SOURCES = seafile-controller.c ../common/log.c
 
 seafile_controller_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -levent \
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ @LIBEVENT_LIBS@ \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZLIB_LIBS@
 
 seafile_controller_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -122,7 +122,7 @@ seaf_daemon_SOURCES = seaf-daemon.c $(common_src)
 
 seaf_daemon_LDADD = $(top_builddir)/lib/libseafile_common.la \
 	@LIB_INTL@ \
-	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/common/index/libindex.la ${LIB_WS32} \
 	@SEARPC_LIBS@ @CCNET_LIBS@ @GNOME_KEYRING_LIBS@ @JANSSON_LIBS@ @LIB_MAC@ @ZLIB_LIBS@
@@ -176,7 +176,7 @@ seaf_daemon_LDFLAGS = @STATIC_COMPILE@ @CONSOLE@
 #seaf_test_LDADD = @CCNET_LIBS@ \
 #	@LIB_INTL@ \
 #	$(top_builddir)/lib/libseafile_common.la \
-#	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+#	@GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 #	$(top_builddir)/common/cdc/libcdc.la \
 #	$(top_builddir)/common/index/libindex.la ${LIB_WS32} \
 #	@SEARPC_LIBS@ @LIB_DIRWATCH@

--- a/fileserver/Makefile.am
+++ b/fileserver/Makefile.am
@@ -44,7 +44,7 @@ fileserver_SOURCES = \
 	../common/seafile-crypt.c
 
 # XXX: -levent_openssl must be behind in -levhtp
-fileserver_LDADD = -levent -levhtp @SSL_LIBS@ -levent_openssl \
+fileserver_LDADD = @LIBEVENT_LIBS@ -levhtp @SSL_LIBS@ -levent_openssl \
 	@GLIB2_LIBS@ @GOBJECT_LIBS@ @LIB_RT@ \
 	@CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile.la \

--- a/fuse/Makefile.am
+++ b/fuse/Makefile.am
@@ -39,7 +39,7 @@ seaf_fuse_SOURCES = seaf-fuse.c \
 seaf_fuse_LDADD = @CCNET_LIBS@ \
 				  $(top_builddir)/lib/libseafile.la \
 				  @GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ \
-                  -lsqlite3 -levent \
+                  -lsqlite3 @LIBEVENT_LIBS@ \
 				  $(top_builddir)/common/cdc/libcdc.la \
 				  @SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @FUSE_LIBS@ @ZLIB_LIBS@
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -53,7 +53,7 @@ libseafile_common_la_SOURCES = ${seafile_object_gen} ${utils_srcs}
 libseafile_common_la_LDFLAGS = -no-undefined
 libseafile_common_la_LIBADD = @GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ -lcrypto @LIB_GDI32@ \
 				     @LIB_UUID@ @LIB_WS32@ @LIB_PSAPI@ -lsqlite3 \
-					 -levent @SEARPC_LIBS@ @LIB_SHELL32@ \
+					 @LIBEVENT_LIBS@ @SEARPC_LIBS@ @LIB_SHELL32@ \
 	@ZLIB_LIBS@
 
 searpc_gen = searpc-signature.h searpc-marshal.h

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -105,7 +105,7 @@ seaf_server_SOURCES = \
 seaf_server_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
 	$(top_builddir)/common/index/libindex.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 

--- a/server/gc/Makefile.am
+++ b/server/gc/Makefile.am
@@ -48,7 +48,7 @@ seafserv_gc_SOURCES = \
 seafserv_gc_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seafserv_gc_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@
@@ -61,7 +61,7 @@ seaf_fsck_SOURCES = \
 seaf_fsck_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seaf_fsck_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@
@@ -73,7 +73,7 @@ seaf_migrate_SOURCES = \
 seaf_migrate_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/common/cdc/libcdc.la \
 	$(top_builddir)/lib/libseafile_common.la \
-	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 -levent \
+	@GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ -lsqlite3 @LIBEVENT_LIBS@ \
 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@
 
 seaf_migrate_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ test_seafile_fmt_CFLAGS = -I$(top_srcdir)/daemon \
 
 test_seafile_fmt_LDADD = @CCNET_LIBS@ \
 	$(top_builddir)/lib/libseafile_common.la \
-	@SSL_LIBS@ -levent @GLIB2_LIBS@
+	@SSL_LIBS@ @LIBEVENT_LIBS@ @GLIB2_LIBS@
 
 test_cdc_SOURCES = test-cdc.c
 


### PR DESCRIPTION
Hi!
This patch helps different systems to set different linker flags for libevent2. In Linux it's set to -levent (as it was previously hardcoded) and in BSD  it's set to -levent_core -levent_extra.
Tested on RHEL6.4 and OpenBSD.
