### PR TITLE
Stop install manuals from other packages

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,5 @@
 if COMPILE_CLIENT
-CLIENT_MANUALS = ccnet.1 seaf-daemon.1 seafile-applet.1 seaf-cli.1
+CLIENT_MANUALS = seaf-daemon.1 seaf-cli.1
 endif
 
 dist_man1_MANS = $(CLIENT_MANUALS)


### PR DESCRIPTION
Hi!
This is needed for another pull request to seafile-client to prevent conflicts.
ccnet manual would be added to ccnet in a short..
