### PR TITLE
Allow configuration of WebDAV server binding using seafdav.conf

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -347,7 +347,7 @@ start_seafdav() {
         "--log-file", seafdav_log_file,
         "--pid", ctl->pidfile[PID_SEAFDAV],
         "--port", port,
-        "--host", "0.0.0.0",
+        "--host", ctl->seafdav_config.public ? "0.0.0.0" : "localhost",
         NULL
     };
 
@@ -358,6 +358,7 @@ start_seafdav() {
         "--log-file", seafdav_log_file,
         "--pid", ctl->pidfile[PID_SEAFDAV],
         "--port", port,
+        "--host", ctl->seafdav_config.public ? "0.0.0.0" : "localhost",
         NULL
     };
 
@@ -818,6 +819,15 @@ read_seafdav_config()
             seaf_message ("Error when reading WEBDAV.fastcgi, use default value 'false'\n");
         }
         ctl->seafdav_config.fastcgi = FALSE;
+    }
+    
+    /* fastcgi */
+    ctl->seafdav_config.public = g_key_file_get_boolean(key_file, "WEBDAV", "public", &error);
+    if (error != NULL) {
+        if (error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
+            seaf_message ("Error when reading WEBDAV.public, use default value 'false'\n");
+        }
+        ctl->seafdav_config.public = FALSE;
     }
 
     /* port */

--- a/controller/seafile-controller.h
+++ b/controller/seafile-controller.h
@@ -32,6 +32,8 @@ enum {
 typedef struct SeafDavConfig {
     gboolean enabled;
     gboolean fastcgi;
+    // should server be publicly available (instead of being bound to localhost)
+    gboolean public;
     int port;
 
 } SeafDavConfig;

--- a/scripts/setup-seafile.sh
+++ b/scripts/setup-seafile.sh
@@ -330,6 +330,7 @@ function gen_seafdav_conf () {
 enabled = false
 port = 8080
 fastcgi = false
+public = false
 share_name = /
 EOF
 ); then


### PR DESCRIPTION
Currently, the WebDAV server binds to localhost if used in fastcgi mode, and to 0.0.0.0 if used in standalone mode.Both may be undesired. It is especially annoying if an external web server is used in conjunction with fastcgi.

This will fix #478.

 