### PR TITLE
Custom WebDAV binding configuration using seafdav.conf

### DIFF
--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -845,7 +845,7 @@ read_seafdav_config()
 	strcpy(ctl->seafdav_config.host,"localhost");
     }
     if(host){
-     	free(host);
+     	g_free(host);
      }
 
     /* port */

--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -347,7 +347,7 @@ start_seafdav() {
         "--log-file", seafdav_log_file,
         "--pid", ctl->pidfile[PID_SEAFDAV],
         "--port", port,
-        "--host", "0.0.0.0",
+        "--host", conf.host,
         NULL
     };
 
@@ -358,6 +358,7 @@ start_seafdav() {
         "--log-file", seafdav_log_file,
         "--pid", ctl->pidfile[PID_SEAFDAV],
         "--port", port,
+        "--host", conf.host,
         NULL
     };
 
@@ -820,6 +821,33 @@ read_seafdav_config()
         ctl->seafdav_config.fastcgi = FALSE;
     }
 
+    /* host */
+    gchar* host = g_key_file_get_string(key_file, "WEBDAV", "host", &error);
+    unsigned char host_valid = 1;
+    if (error != NULL) {
+        if (error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
+            seaf_message ("Error when reading WEBDAV.host, use default value 'localhost'\n");
+        }
+	host_valid = 0;
+    }else{
+	// no error occured while reading host, validate it
+        size_t len = strnlen(host,SEAFDAV_MAX_HOST + 1);
+        if(len ==  0 || len > SEAFDAV_MAX_HOST){
+	    seaf_message ("Error when validating WEBDAV.host, use default value 'localhost'\n");
+	    host_valid = 0;
+	}
+    }
+    if(host_valid){
+	// copy entered host to seafdav settings
+	strncpy(ctl->seafdav_config.host,host,SEAFDAV_MAX_HOST);
+    }else{
+	// use default 'localhost'
+	strcpy(ctl->seafdav_config.host,"localhost");
+    }
+    if(host){
+     	free(host);
+     }
+
     /* port */
     ctl->seafdav_config.port = g_key_file_get_integer(key_file, "WEBDAV", "port", &error);
     if (error != NULL) {
@@ -839,7 +867,6 @@ out:
     if (key_file) {
         g_key_file_free (key_file);
     }
-
     g_free (seafdav_conf);
 
     return ret;
@@ -981,3 +1008,4 @@ int main (int argc, char **argv)
 
     return 0;
 }
+

--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -823,26 +823,28 @@ read_seafdav_config()
 
     /* host */
     gchar* host = g_key_file_get_string(key_file, "WEBDAV", "host", &error);
+    // set default host depending on fastcgi setting in order to preserve default behaviour
+    const char* host_default = ctl->seafdav_config.fastcgi ? "localhost" : "0.0.0.0";
     gboolean host_valid = TRUE;
     if (error != NULL) {
         if (error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
-            seaf_message ("Error when reading WEBDAV.host, use default value 'localhost'\n");
+            seaf_message ("Error when reading WEBDAV.host, use default value '%s'\n", host_default);
         }
 	host_valid = FALSE;
     }else{
 	// no error occured while reading host, validate it
         size_t len = strnlen(host,SEAFDAV_MAX_HOST + 1);
         if(len ==  0 || len > SEAFDAV_MAX_HOST){
-	    seaf_message ("Error when validating WEBDAV.host, use default value 'localhost'\n");
+	    seaf_message ("Error when validating WEBDAV.host, use default value '%s'\n", host_default);
 	    host_valid = FALSE;
 	}
     }
     if(host_valid){
-	// copy entered host to seafdav settings
-	strncpy(ctl->seafdav_config.host,host,SEAFDAV_MAX_HOST);
+        // copy entered host to seafdav settings
+        strncpy(ctl->seafdav_config.host,host,SEAFDAV_MAX_HOST);
     }else{
-	// use default 'localhost'
-	strcpy(ctl->seafdav_config.host,"localhost");
+        // use default value
+        strcpy(ctl->seafdav_config.host, host_default);
     }
     if(host){
      	g_free(host);

--- a/controller/seafile-controller.c
+++ b/controller/seafile-controller.c
@@ -823,18 +823,18 @@ read_seafdav_config()
 
     /* host */
     gchar* host = g_key_file_get_string(key_file, "WEBDAV", "host", &error);
-    unsigned char host_valid = 1;
+    gboolean host_valid = TRUE;
     if (error != NULL) {
         if (error->code != G_KEY_FILE_ERROR_KEY_NOT_FOUND) {
             seaf_message ("Error when reading WEBDAV.host, use default value 'localhost'\n");
         }
-	host_valid = 0;
+	host_valid = FALSE;
     }else{
 	// no error occured while reading host, validate it
         size_t len = strnlen(host,SEAFDAV_MAX_HOST + 1);
         if(len ==  0 || len > SEAFDAV_MAX_HOST){
 	    seaf_message ("Error when validating WEBDAV.host, use default value 'localhost'\n");
-	    host_valid = 0;
+	    host_valid = FALSE;
 	}
     }
     if(host_valid){

--- a/controller/seafile-controller.h
+++ b/controller/seafile-controller.h
@@ -29,10 +29,15 @@ enum {
     N_PID
 };
 
+// host size limit (39 charaters: max ipv6 size)
+#define SEAFDAV_MAX_HOST 39
+
 typedef struct SeafDavConfig {
     gboolean enabled;
     gboolean fastcgi;
     int port;
+    // host to bind server to
+    gchar host[SEAFDAV_MAX_HOST + 1];
 
 } SeafDavConfig;
 

--- a/scripts/setup-seafile.sh
+++ b/scripts/setup-seafile.sh
@@ -330,7 +330,7 @@ function gen_seafdav_conf () {
 enabled = false
 port = 8080
 fastcgi = false
-host = localhost
+host = 0.0.0.0
 share_name = /
 EOF
 ); then

--- a/scripts/setup-seafile.sh
+++ b/scripts/setup-seafile.sh
@@ -330,6 +330,7 @@ function gen_seafdav_conf () {
 enabled = false
 port = 8080
 fastcgi = false
+host = localhost
 share_name = /
 EOF
 ); then


### PR DESCRIPTION
This is an extended version of https://github.com/haiwen/seafile/pull/1084, allowing to specify a custom host in the *seafdav.conf* file, fixing #478.

Currently, the WebDAV server binds to localhost if used in fastcgi mode, and to 0.0.0.0 if used in standalone mode. Both may be undesired. It is especially annoying if an external web server is used in conjunction with fastcgi.