### PR TITLE
seafile-admin: exit after noting that ccnet dir already exists

### DIFF
--- a/tools/seafile-admin
+++ b/tools/seafile-admin
@@ -319,6 +319,7 @@ def get_ccnet_conf_dir():
                 conf[CONF_CCNET_CONF_EXISTS] = True
         else:
             print 'Please remove the directory %s first, and run the script again' % ccnet_conf_dir
+            sys.exit(1)
     else:
         conf[CONF_CCNET_CONF_EXISTS] = False
 


### PR DESCRIPTION
Steps to reproduce:
- Create the following directory structure (per the [server build instructions](http://manual.seafile.com/build_seafile/server.html)):

```
seafile
|- seafile-server
|   |- seafile-source
|   |_ seahub
|_ ccnet
```
- Install the Python dependencies for seahub.
- From the `seafile` directory, run `seafile-server/seafile-source/tools/seafile-admin setup`
  - **Expected**: gives an error message and exits
  - **Actual**: gives error message, then a traceback:

``` pytb
Traceback (most recent call last):
  File "seafile-server/seafile-source/tools/seafile-admin", line 861, in <module>
    main()
  File "seafile-server/seafile-source/tools/seafile-admin", line 858, in main
    args.func(args)
  File "seafile-server/seafile-source/tools/seafile-admin", line 730, in setup_seafile
    config_ccnet_seafile()
  File "seafile-server/seafile-source/tools/seafile-admin", line 516, in config_ccnet_seafile
    if not conf[CONF_CCNET_CONF_EXISTS]:
KeyError: 'ccnet_conf_exists'
```
