### PR TITLE
[client] Display repo worktree folder sync status better.

### DIFF
--- a/common/rpc-service.c
+++ b/common/rpc-service.c
@@ -587,6 +587,8 @@ seafile_get_repo_sync_task (const char *repo_id, GError **error)
         sync_state = "waiting for sync";
     } else {
         sync_state = sync_state_to_str(task->state);
+        if (strcmp(sync_state, "error") == 0 && !info->in_error)
+            sync_state = "synchronized";
     }
 
 
@@ -829,12 +831,17 @@ seafile_get_path_sync_status (const char *repo_id,
         return NULL;
     }
 
-    if (*path == '/')
-        ++path;
-    canon_path = g_strdup(path);
-    len = strlen(canon_path);
-    if (canon_path[len-1] == '/')
-        canon_path[len-1] = 0;
+    /* Empty path means to get status of the worktree folder. */
+    if (strcmp (path, "") != 0) {
+        if (*path == '/')
+            ++path;
+        canon_path = g_strdup(path);
+        len = strlen(canon_path);
+        if (canon_path[len-1] == '/')
+            canon_path[len-1] = 0;
+    } else {
+        canon_path = g_strdup(path);
+    }
 
     status = seaf_sync_manager_get_path_sync_status (seaf->sync_mgr,
                                                      repo_id,

--- a/daemon/sync-mgr.h
+++ b/daemon/sync-mgr.h
@@ -19,6 +19,8 @@ struct _SyncInfo {
     gboolean   in_sync;         /* set to FALSE when sync state is DONE or ERROR */
 
     gint       err_cnt;
+    gboolean   in_error;        /* set to TRUE if err_cnt >= 3 */
+
     gboolean   deleted_on_relay;
     gboolean   branch_deleted_on_relay;
     gboolean   repo_corrupted;
@@ -94,6 +96,7 @@ enum _SyncStatus {
     SYNC_STATUS_ERROR,
     SYNC_STATUS_IGNORED,
     SYNC_STATUS_SYNCED,
+    SYNC_STATUS_PAUSED,
     N_SYNC_STATUS,
 };
 typedef enum _SyncStatus SyncStatus;


### PR DESCRIPTION
- When "path" paramter is empty, return sync status for the worktree folder
- When querying worktree folder sync status, a new state "paused" can be returned
- Turn user visible repo status to "error" after 3 times of internal sync failures. This is reflected in folder sync status and the applet main window.