### PR TITLE
add regenerate_secret_key.sh for 4.3.0 upgrade

### DIFF
--- a/scripts/upgrade/regenerate_secret_key.sh
+++ b/scripts/upgrade/regenerate_secret_key.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SCRIPT=$(readlink -f "$0")
+UPGRADEDIR=$(dirname "${SCRIPT}")
+INSTALLPATH=$(dirname "${UPGRADEDIR}")
+TOPDIR=$(dirname "${INSTALLPATH}")
+
+seahub_secret_keygen=${INSTALLPATH}/seahub/tools/secret_key_generator.py
+seahub_settings_py=${TOPDIR}/seahub_settings.py
+
+line="SECRET_KEY = \"$(python $seahub_secret_keygen)\""
+
+sed -i -e "/SECRET_KEY/c\\$line" $seahub_settings_py


### PR DESCRIPTION
According to [django docs](https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-SECRET_KEY), after regenerating the secret key:

- all the sessions would be logged out
-  `password_reset()` tokens would be invalid

We're ok with these consequences.
