### PR TITLE
preserve the owner, group and umask

### DIFF
--- a/scripts/upgrade/upgrade_4.4_5.0.sh
+++ b/scripts/upgrade/upgrade_4.4_5.0.sh
@@ -211,7 +211,7 @@ function copy_confs_to_central_conf_dir() {
             continue
         fi
         cp $conffile $conffile.seafile-5.0.0-bak
-        cp -v $conffile $default_conf_dir/
+        cp -av $conffile $default_conf_dir/
         cat >$conffile<<EOF
 # This file has been moved to $default_conf_dir/$(basename $conffile) in seafile 5.0.0
 EOF


### PR DESCRIPTION
This is a follow up pull request to the already closed issue #1429 The problem is not on the users end. It's the way the upgrade Script moves the config files to the new locations.

The upgrade script does copy the configs like this

    cp -v $conffile $default_conf_dir/

If you execute the upgrade script with root priviliges the copied filed will have the rights of the user logged in (in this case root).

The correct way would be to preserve the owner, group and umask

    cp -av $conffile $default_conf_dir/


