### PR TITLE
Fix use of wrong python version

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -64,7 +64,7 @@ rpc_table.stamp: ${top_srcdir}/lib/rpc_table.py
 	@rm -f rpc_table.tmp
 	@touch rpc_table.tmp
 	@echo "[libsearpc]: generating rpc header files"
-	@PYTHON@ `which searpc-codegen.py` ${top_srcdir}/lib/rpc_table.py
+	searpc-codegen.py ${top_srcdir}/lib/rpc_table.py
 	@echo "[libsearpc]: done"
 	@mv -f rpc_table.tmp $@
 


### PR DESCRIPTION
searpc-codegen.py is not compatible with python3. 

moreover it contains a hashbang to use python2, so it is not necessary to define a specific interpreter:

    x@x ~ $ head -n1 /usr/bin/searpc-codegen.py 
    #!/usr/bin/env python2

Running it with python 3 as default fails.

please merge
