### PR TITLE
[client] Support periodic sync.

### DIFF
--- a/common/rpc-service.c
+++ b/common/rpc-service.c
@@ -1293,7 +1293,7 @@ int do_unsync_repo(SeafRepo *repo)
         return -1;
     }
 
-    if (repo->auto_sync)
+    if (repo->auto_sync && (repo->sync_interval == 0))
         seaf_wt_monitor_unwatch_repo (seaf->wt_monitor, repo->id);
 
     seaf_sync_manager_cancel_sync_task (seaf->sync_mgr, repo->id);

--- a/daemon/clone-mgr.c
+++ b/daemon/clone-mgr.c
@@ -126,7 +126,7 @@ mark_clone_done_v2 (SeafRepo *repo, CloneTask *task)
     if (task->server_url)
         repo->server_url = g_strdup(task->server_url);
 
-    if (repo->auto_sync) {
+    if (repo->auto_sync && (repo->sync_interval == 0)) {
         if (seaf_wt_monitor_watch_repo (seaf->wt_monitor,
                                         repo->id, repo->worktree) < 0) {
             seaf_warning ("failed to watch repo %s(%.10s).\n", repo->name, repo->id);

--- a/daemon/repo-mgr.h
+++ b/daemon/repo-mgr.h
@@ -29,6 +29,7 @@
 #define REPO_PROP_DOWNLOAD_HEAD "download-head"
 #define REPO_PROP_IS_READONLY "is-readonly"
 #define REPO_PROP_SERVER_URL  "server-url"
+#define REPO_PROP_SYNC_INTERVAL "sync-interval"
 
 struct _SeafRepoManager;
 typedef struct _SeafRepo SeafRepo;
@@ -98,6 +99,9 @@ struct _SeafRepo {
     /* Detected file change set during indexing.
      * Added to here to avoid passing additional arguments. */
     struct _ChangeSet *changeset;
+
+    /* Non-zero if periodic sync is set for this repo. */
+    int sync_interval;
 };
 
 


### PR DESCRIPTION
This feature is controlled by setting "sync-interval" property of
a repo. If the property is not set or <= 0, it's disabled; if it's
> 0, sync the repo every specified seconds.

If periodic sync is set for a repo, auto change detection is
disabled. And in every sync, the worktree is scanned, and latest
changes from the server is downloaded.