### PR TITLE
 curl: avoid race conditions with crypto-functionality by using the CRYPTO_* functions from openssl

### DIFF
--- a/common/curl-init.c
+++ b/common/curl-init.c
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <curl/curl.h>
+#include <openssl/crypto.h>
+#include <pthread.h>
+
+#include "curl-init.h"
+
+pthread_mutex_t* curl_locks = NULL;
+
+void seafile_curl_locking_callback(int mode, int n, const char* file, int line)
+{
+    if (mode & CRYPTO_LOCK) {
+        pthread_mutex_lock (&curl_locks[n]);
+    } else {
+        pthread_mutex_unlock (&curl_locks[n]);
+    }
+}
+
+void seafile_curl_init()
+{
+    int i;
+    curl_locks = malloc (sizeof(pthread_mutex_t) * CRYPTO_num_locks());
+    for (i = 0; i < CRYPTO_num_locks(); ++i) {
+        pthread_mutex_init (&curl_locks[i], NULL);
+    }
+
+    CRYPTO_set_id_callback (pthread_self);
+    CRYPTO_set_locking_callback (seafile_curl_locking_callback);
+}
+
+void seafile_curl_deinit()
+{
+    int i;
+    CRYPTO_set_id_callback (0);
+    CRYPTO_set_locking_callback (0);
+
+    for (i = 0; i < CRYPTO_num_locks(); ++i) {
+        pthread_mutex_destroy (&curl_locks[i]);
+    }
+    free (curl_locks);
+}

--- a/common/curl-init.h
+++ b/common/curl-init.h
@@ -1,0 +1,9 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef __CURL_INIT_H__
+#define __CURL_INIT_H__
+
+void seaf_curl_init(void);
+void seaf_curl_deinit(void);
+
+#endif

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -99,6 +99,7 @@ common_src = \
 	../common/block-backend.c \
 	../common/block-backend-fs.c \
 	../common/mq-mgr.c \
+	../common/curl-init.c \
 	block-tx-client.c \
 	../common/block-tx-utils.c \
 	client-migrate.c \

--- a/daemon/seaf-daemon.c
+++ b/daemon/seaf-daemon.c
@@ -31,6 +31,7 @@
 #include "utils.h"
 #include "vc-utils.h"
 #include "seafile-config.h"
+#include "curl-init.h"
 
 #include "processors/check-tx-slave-proc.h"
 
@@ -541,11 +542,13 @@ main (int argc, char **argv)
 
     set_signal_handlers (seaf);
 
+    seafile_curl_init();
     seafile_session_prepare (seaf);
     seafile_session_start (seaf);
 
     seafile_session_config_set_string (seaf, "wktree", seaf->worktree_dir);
     ccnet_main (client);
+    seafile_curl_deinit();
 
     return 0;
 }


### PR DESCRIPTION
This patch sets up the callbacks inside openssl to enable the multi-threaded use of the openssl library.
The problem that occured can be found in https://github.com/haiwen/seafile/issues/1528

I tested it successfully under Debian/Linux.