### PR TITLE
setup: Do not try to generate seahub db when it exists

### DIFF
--- a/scripts/setup-seafile-mysql.py
+++ b/scripts/setup-seafile-mysql.py
@@ -1241,7 +1241,8 @@ def main():
     seafile_config.ask_questions()
     seahub_config.ask_questions()
 
-    if AbstractDBConfigurator.ask_use_existing_db():
+    use_existing_db = AbstractDBConfigurator.ask_use_existing_db()
+    if use_existing_db:
         db_config = ExistingDBConfigurator()
     else:
         db_config = NewDBConfigurator()
@@ -1257,7 +1258,8 @@ def main():
     seafdav_config.generate()
     seahub_config.generate()
 
-    seahub_config.do_syncdb()
+    if not use_existing_db:
+        seahub_config.do_syncdb()
     seahub_config.prepare_avatar_dir()
     # db_config.create_seahub_admin()
     user_manuals_handler.copy_user_manuals()


### PR DESCRIPTION
When using `setup-seafile-mysql.sh` it asks you if you want to use an
existing database or create a new one. Even when you choose the 'Use
existing' option, it tries to create the seahub DB, and then the
installer fails because it tries to create already existing tables.

Fix is to remember the answer to the previous choice and only create the
seahub DB if you are creating a new DB.