### PR TITLE
[client] Support server properties.

### DIFF
--- a/common/rpc-service.c
+++ b/common/rpc-service.c
@@ -920,6 +920,37 @@ seafile_mark_file_unlocked (const char *repo_id, const char *path, GError **erro
     return ret;
 }
 
+char *
+seafile_get_server_property (const char *server_url, const char *key, GError **error)
+{
+    if (!server_url || !key) {
+        g_set_error (error, SEAFILE_DOMAIN, SEAF_ERR_BAD_ARGS,
+                     "Argument should not be null");
+        return NULL;
+    }
+
+    return seaf_repo_manager_get_server_property (seaf->repo_mgr,
+                                                  server_url,
+                                                  key);
+}
+
+int
+seafile_set_server_property (const char *server_url,
+                             const char *key,
+                             const char *value,
+                             GError **error)
+{
+    if (!server_url || !key || !value) {
+        g_set_error (error, SEAFILE_DOMAIN, SEAF_ERR_BAD_ARGS,
+                     "Argument should not be null");
+        return -1;
+    }
+
+    return seaf_repo_manager_set_server_property (seaf->repo_mgr,
+                                                  server_url,
+                                                  key, value);
+}
+
 #endif  /* not define SEAFILE_SERVER */
 
 /*

--- a/daemon/clone-mgr.c
+++ b/daemon/clone-mgr.c
@@ -2421,8 +2421,22 @@ out:
 static void
 check_folder_permissions (CloneTask *task)
 {
+    SeafRepo *repo = NULL;
     HttpFolderPermReq *req;
     GList *requests = NULL;
+
+    repo = seaf_repo_manager_get_repo (seaf->repo_mgr, task->repo_id);
+    if (repo == NULL) {
+        seaf_warning ("[Clone mgr] cannot find repo %s after fetched.\n", 
+                      task->repo_id);
+        transition_to_error (task, CLONE_ERROR_INTERNAL);
+        return;
+    }
+
+    if (!seaf_repo_manager_server_is_pro (seaf->repo_mgr, task->server_url)) {
+        mark_clone_done_v2 (repo, task);
+        return;
+    }
 
     req = g_new0 (HttpFolderPermReq, 1);
     memcpy (req->repo_id, task->repo_id, 36);

--- a/daemon/repo-mgr.h
+++ b/daemon/repo-mgr.h
@@ -374,6 +374,23 @@ seaf_repo_manager_update_repos_server_host (SeafRepoManager *mgr,
                                             const char *new_host,
                                             const char *new_server_url);
 
+#define SERVER_PROP_IS_PRO "is_pro"
+
+char *
+seaf_repo_manager_get_server_property (SeafRepoManager *mgr,
+                                       const char *server_url,
+                                       const char *key);
+
+int
+seaf_repo_manager_set_server_property (SeafRepoManager *mgr,
+                                       const char *server_url,
+                                       const char *key,
+                                       const char *value);
+
+gboolean
+seaf_repo_manager_server_is_pro (SeafRepoManager *mgr,
+                                 const char *server_url);
+
 GList *
 seaf_repo_load_ignore_files (const char *worktree);
 

--- a/daemon/seaf-daemon.c
+++ b/daemon/seaf-daemon.c
@@ -294,6 +294,16 @@ start_rpc_service (CcnetClient *client)
                                      seafile_generate_magic_and_random_key,
                                      "seafile_generate_magic_and_random_key",
                                      searpc_signature_object__int_string_string());
+
+    searpc_server_register_function ("seafile-rpcserver",
+                                     seafile_get_server_property,
+                                     "seafile_get_server_property",
+                                     searpc_signature_string__string_string());
+
+    searpc_server_register_function ("seafile-rpcserver",
+                                     seafile_set_server_property,
+                                     "seafile_set_server_property",
+                                     searpc_signature_int__string_string_string());
 }
 
 static void

--- a/daemon/sync-mgr.c
+++ b/daemon/sync-mgr.c
@@ -2467,6 +2467,9 @@ check_folder_permissions_one_server (SeafSyncManager *mgr,
     HttpFolderPermReq *req;
     GList *requests = NULL;
 
+    if (!seaf_repo_manager_server_is_pro (seaf->repo_mgr, host))
+        return;
+
     gint64 now = (gint64)time(NULL);
 
     if (server_state->http_version == 0 ||
@@ -2582,9 +2585,9 @@ check_server_locked_files_done (HttpLockedFiles *result, void *user_data)
 
 static void
 check_locked_files_one_server (SeafSyncManager *mgr,
-                                     const char *host,
-                                     HttpServerState *server_state,
-                                     GList *repos)
+                               const char *host,
+                               HttpServerState *server_state,
+                               GList *repos)
 {
     GList *ptr;
     SeafRepo *repo;
@@ -2592,6 +2595,9 @@ check_locked_files_one_server (SeafSyncManager *mgr,
     gint64 timestamp;
     HttpLockedFilesReq *req;
     GList *requests = NULL;
+
+    if (!seaf_repo_manager_server_is_pro (seaf->repo_mgr, host))
+        return;
 
     gint64 now = (gint64)time(NULL);
 

--- a/include/seafile-rpc.h
+++ b/include/seafile-rpc.h
@@ -223,6 +223,15 @@ seafile_mark_file_locked (const char *repo_id, const char *path, GError **error)
 int
 seafile_mark_file_unlocked (const char *repo_id, const char *path, GError **error);
 
+char *
+seafile_get_server_property (const char *server_url, const char *key, GError **error);
+
+int
+seafile_set_server_property (const char *server_url,
+                             const char *key,
+                             const char *value,
+                             GError **error);
+
 /**
  * seafile_list_dir:
  * List a directory.


### PR DESCRIPTION
Server properties can be set by RPC set_server_property (server_url, key, value).

Currently only one server property is defined: "is_pro". You can set it to "true" or "false".