### PR TITLE
add scripts to run the integration tests easily

### DIFF
--- a/run_docker_integration_tests.sh
+++ b/run_docker_integration_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+THISDIR="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER=ubuntu:14.04
+
+echo "Pulling last version of container $CONTAINER"
+(set -x ; docker pull "$CONTAINER")
+
+echo "Executing run_integration_tests.sh inside the $CONTAINER container."
+(set -x ; docker run -v "$THISDIR":/opt/seafile/seafile -t "$CONTAINER" /opt/seafile/seafile/run_integration_tests.sh)

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -x
+
+THISDIR="$(cd "$(dirname "$0")" && pwd)"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+	build-essential \
+	ccache \
+	curl \
+	flex \
+	git \
+	intltool \
+	libarchive-dev \
+	libcurl4-openssl-dev \
+	libevent-dev \
+	libfuse-dev \
+	libjansson-dev \
+	libmysqlclient-dev \
+	libonig-dev \
+	libpython-dev \
+	libsqlite3-dev \
+	libssl-dev \
+	libssl1.0.0 \
+	libtool \
+	mysql-client \
+	mysql-server \
+	net-tools \
+	openssl \
+	python \
+	python-pip \
+	re2c \
+	sqlite3 \
+	uuid-dev \
+	valac \
+	wget \
+&& true
+
+/etc/init.d/mysql start
+ccache -s
+export PATH=/usr/lib/ccache:${PATH}
+
+cd "$THISDIR"
+
+./integration-tests/install-deps.sh
+
+./integration-tests/run.py


### PR DESCRIPTION
Also add one to run the integration tests inside a docker container
based on ubuntu 14.04.

To run them you only need docker and then execute:

```
./run_docker_integration_tests.sh
```

It will run a ubuntu:14.04 container, mount the current folder as a
volume inside the container and execute the integration tests inside the
container.
