### PR TITLE
[install-scripts] customize url/branch of projects via envars

### DIFF
--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -70,7 +70,8 @@ def prepend_env_value(name, value, seperator=':', env=None):
 def get_project_branch(project, default_branch='master'):
     if project.name == 'seafile':
         return TRAVIS_BRANCH
-    env_branch = os.environ.get('PROJECT_' + project.name.upper() + '_BRANCH')
+    env_branch = (os.environ.get('PROJECT_' + project.name.upper() + '_BRANCH') or
+                  os.environ.get('PROJECT_ALL_BRANCH'))
     if env_branch:
         return env_branch
     conf = json.loads(requests.get(
@@ -88,7 +89,9 @@ class Project(object):
 
     @property
     def url(self):
-        default_url = 'https://www.github.com/haiwen/{}.git'.format(self.name)
+        base_url = os.environ.get('PROJECT_ALL_BASE_URL',
+                                  'https://www.github.com/haiwen')
+        default_url = '{}/{}.git'.format(base_url, self.name)
         return os.environ.get('PROJECT_' + self.name.upper() + '_URL', default_url)
 
     @property

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -70,6 +70,9 @@ def prepend_env_value(name, value, seperator=':', env=None):
 def get_project_branch(project, default_branch='master'):
     if project.name == 'seafile':
         return TRAVIS_BRANCH
+    env_branch = os.environ.get('PROJECT_' + project.name.upper() + '_BRANCH')
+    if env_branch:
+        return env_branch
     conf = json.loads(requests.get(
         'https://raw.githubusercontent.com/haiwen/seafile-test-deploy/master/branches.json').text)
     return conf.get(TRAVIS_BRANCH, {}).get(project.name,
@@ -85,7 +88,8 @@ class Project(object):
 
     @property
     def url(self):
-        return 'https://www.github.com/haiwen/{}.git'.format(self.name)
+        default_url = 'https://www.github.com/haiwen/{}.git'.format(self.name)
+        return os.environ.get('PROJECT_' + self.name.upper() + '_URL', default_url)
 
     @property
     def projectdir(self):

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -70,7 +70,8 @@ def prepend_env_value(name, value, seperator=':', env=None):
 def get_project_branch(project, default_branch='master'):
     if project.name == 'seafile':
         return TRAVIS_BRANCH
-    env_branch = (os.environ.get('PROJECT_' + project.name.upper() + '_BRANCH') or
+    name = project.name.upper()
+    env_branch = (os.environ.get('PROJECT_' + name + '_BRANCH') or
                   os.environ.get('PROJECT_ALL_BRANCH'))
     if env_branch:
         return env_branch
@@ -92,7 +93,8 @@ class Project(object):
         base_url = os.environ.get('PROJECT_ALL_BASE_URL',
                                   'https://www.github.com/haiwen')
         default_url = '{}/{}.git'.format(base_url, self.name)
-        return os.environ.get('PROJECT_' + self.name.upper() + '_URL', default_url)
+        return os.environ.get('PROJECT_' + self.name.upper() + '_URL',
+                              default_url)
 
     @property
     def projectdir(self):


### PR DESCRIPTION
When building seafile it fetches its dependencies from a hardcoded
github url. This commit permit running the integration tests and
building the final installer package using seahub (for example) from
another repo/branch than the default one by defining the environment
variable PROJECT_SEAFILE_URL and PROJECT_SEAFILE_BRANCH to point to a
git repo and branch reference, respectively.
