### PR TITLE
Revert "Require qt 5.5+ in deb packages."

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,11 +28,11 @@ Depends:
 	libuuid1,
 	libssl0.9.8 | libssl1.0.0,
 	libevent-2.0-5,
-    libqt5network5 (>=5.5),
-    libqt5core5a (>=5.5),
-    libqt5gui5 (>=5.5),
-    libqt5webkit5 (>=5.5),
-    libqt5test5 (>=5.5)
+    libqt5network5,
+    libqt5core5a,
+    libqt5gui5,
+    libqt5webkit5,
+    libqt5test5
 Description: Client of seafile, an online file storage and collaboration tool
  Seafile enables you to build private cloud for file sharing and collaboration
  among team members in your company/organization. This is the Linux desktop


### PR DESCRIPTION
This reverts commit 8856db42f34250eb28b5ae0b6e4d886f0f3ee546.

I'll follow up with a PR to seafile-docs about how to fix the qt5 tray icon problem under linux.