### PR TITLE
[Seafile-server 6.0.0] Use valid default tokenv2 creation datetime

### DIFF
--- a/scripts/upgrade/sql/6.0.0/sqlite3/seahub.sql
+++ b/scripts/upgrade/sql/6.0.0/sqlite3/seahub.sql
@@ -21,4 +21,4 @@ CREATE INDEX IF NOT EXISTS "invitations_invitation_94a08da1" ON "invitations_inv
 CREATE INDEX IF NOT EXISTS "invitations_invitation_d5dd16f8" ON "invitations_invitation" ("inviter");
 
 ALTER TABLE api2_tokenv2 ADD COLUMN wiped_at datetime DEFAULT NULL;
-ALTER TABLE api2_tokenv2 ADD COLUMN created_at datetime NOT NULL DEFAULT '0000-00-00 00:00:00';
+ALTER TABLE api2_tokenv2 ADD COLUMN created_at datetime NOT NULL DEFAULT '0001-01-01 00:00:00';


### PR DESCRIPTION
Hi,
After upgrade, Seahub crashes with error:

```
2016-08-13 01:43:03,844 [ERROR] django.request:256 handle_uncaught_exception Internal Server Error: /api2/account/info/
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/srv/seafile/example.com/seafile-server/seahub/seahub/api2/base.py", line 23, in dispatch
    response = super(APIView, self).dispatch(*a, **kw)
  File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 466, in dispatch
    response = self.handle_exception(exc)
  File "/srv/seafile/example.com/seafile-server/seahub/seahub/api2/base.py", line 20, in handle_exception
    return super(APIView, self).handle_exception(exc)
  File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 454, in dispatch
    self.initial(request, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 376, in initial
    self.perform_authentication(request)
  File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 310, in perform_authentication
    request.user
  File "/usr/lib/python2.7/site-packages/rest_framework/request.py", line 353, in __getattribute__
    return super(Request, self).__getattribute__(attr)
  File "/usr/lib/python2.7/site-packages/rest_framework/request.py", line 193, in user
    self._authenticate()
  File "/usr/lib/python2.7/site-packages/rest_framework/request.py", line 316, in _authenticate
    user_auth_tuple = authenticator.authenticate(self)
  File "/srv/seafile/example.com/seafile-server/seahub/seahub/api2/authentication.py", line 63, in authenticate
    ret = self.authenticate_v2(request, key)
  File "/srv/seafile/example.com/seafile-server/seahub/seahub/api2/authentication.py", line 92, in authenticate_v2
    token = TokenV2.objects.get(key=key)
  File "/usr/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 328, in get
    num = len(clone)
  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 144, in __len__
    self._fetch_all()
  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 965, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/usr/lib/python2.7/site-packages/django/db/models/query.py", line 238, in iterator
    results = compiler.execute_sql()
  File "/usr/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 840, in execute_sql
    cursor.execute(sql, params)
  File "/usr/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/usr/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py", line 318, in execute
    return Database.Cursor.execute(self, query, params)
  File "/usr/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py", line 69, in <lambda>
    return lambda s: conv_func(s.decode('utf-8'))
  File "/usr/lib/python2.7/site-packages/django/db/backends/sqlite3/utils.py", line 7, in parse_datetime_with_timezone_support
    dt = parse_datetime(value)
  File "/usr/lib/python2.7/site-packages/django/utils/dateparse.py", line 109, in parse_datetime
    return datetime.datetime(**kw)
ValueError: year is out of range
```
According to [https://docs.python.org/2/library/datetime.html](url), the smallest year number allowed in a date or datetime object. MINYEAR is 1

Quick workaround:
```
sqlite3 /path/to/seahub.db
UPDATE api2_tokenv2 SET created_at='0001-01-01 00:00:00' WHERE created_at='0000-00-00 00:00:00';
.quit
```