### PR TITLE
Add support for PKG_CONFIG_PATH/PKG_CONFIG_LIBDIR env vars for libcrypto and libssl

### DIFF
--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -13,6 +13,7 @@ AM_CFLAGS = -DPKGDATADIR=\"$(pkgdatadir)\" \
 	@CURL_CFLAGS@ \
 	@BPWRAPPER_CFLAGS@ \
 	@GNUTLS_CFLAGS@ \
+	@SSL_CFLAGS@ \
 	-Wall
 
 bin_PROGRAMS = seaf-daemon


### PR DESCRIPTION
This enables support for compiling seafile using an OpenSSL version installed outside the system's default prefix. Until seafile supports openssl 1.1.0, this is required to compile for example on Archlinux where the current openssl 1.0.2 package will soon be upgraded to 1.1.0, and the future 1.0.2 package's files will go into /usr/lib/openssl-1.0.

To use this, execute `export PKG_CONFIG_PATH=/usr/lib/openssl-1.0/lib/pkgconfig` prior to running `autogen.sh`.