### PR TITLE
update build msi tool Paraffin

### DIFF
--- a/msi/Makefile
+++ b/msi/Makefile
@@ -31,7 +31,7 @@ sources = WixUI_InstallDir_NoLicense.wxs MyInstallDirDlg.wxs \
 OBJECTS = ${sources:%.wxs=%.wixobj} 
 
 fragment.wxs: 
-	Paraffin.exe -dir bin -g -alias bin -custom bin fragment.wxs
+	Paraffin.exe -dir bin -alias bin -groupname bin fragment.wxs
 
 %.wixobj : %.wxs
 	$(CC) $(CFLAGS) $< -o $@


### PR DESCRIPTION
原语句Paraffin.exe -dir bin -g -alias bin -custom bin fragment.wxs

旧：
-custom:应用于所有生成的组件和文件的唯一值。
-g: 为所有组件生成GUID


新：
-groupname:生成的片段的<ComponentGroup> Id属性值。 （简称：-gn）