### PR TITLE
Initialize file_descr->file_size

### DIFF
--- a/common/cdc/cdc.c
+++ b/common/cdc/cdc.c
@@ -61,6 +61,7 @@ static int init_cdc_file_descriptor (int fd,
     int block_min_sz = 0;
 
     file_descr->block_nr = 0;
+    file_descr->file_size = 0;
 
     if (file_descr->block_min_sz <= 0)
         file_descr->block_min_sz = BLOCK_MIN_SZ;


### PR DESCRIPTION
file_descr->file_size  is not initialized in the function init_cdc_file_descriptor().
in file_chunk_cdc(),it is first used like:
```c
...
ret = readn (fd_src, buf + tail, rsize);
if (ret < 0) {
    seaf_warning ("CDC: failed to read: %s.\n", strerror(errno));
    ret = -1;
    goto out;
}
tail += ret;
file_descr->file_size += ret;
...
```

The value is indeterminate sometimes。