### PR TITLE
Fix build with curl 7.62.0

### DIFF
--- a/daemon/http-tx-mgr.c
+++ b/daemon/http-tx-mgr.c
@@ -1138,7 +1138,9 @@ curl_error_to_http_task_error (int curl_error)
     case CURLE_SSL_CONNECT_ERROR:
     case CURLE_PEER_FAILED_VERIFICATION:
     case CURLE_SSL_CERTPROBLEM:
+#if LIBCURL_VERSION_NUM < 0x073e00
     case CURLE_SSL_CACERT:
+#endif
     case CURLE_SSL_CACERT_BADFILE:
     case CURLE_SSL_ISSUER_ERROR:
         return HTTP_TASK_ERR_SSL;


### PR DESCRIPTION
from CHANGES:
ssl: deprecate CURLE_SSL_CACERT in favour of a unified error code
Long live CURLE_PEER_FAILED_VERIFICATION