### PR TITLE
Delete the declaration of inet_ntop and inet_pton because these funct…

### DIFF
--- a/lib/net.h
+++ b/lib/net.h
@@ -40,8 +40,6 @@
 
 #ifdef WIN32
 extern int inet_aton(const char *string, struct in_addr *addr);
-extern const char *inet_ntop(int af, const void *src, char *dst, size_t size);
-extern int inet_pton(int af, const char *src, void *dst);
 #endif
 
 evutil_socket_t ccnet_net_open_tcp (const struct sockaddr *sa, int nonblock);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -52,7 +52,6 @@
 
 #include "log.h"
 
-extern int inet_pton(int af, const char *src, void *dst);
 
 
 void


### PR DESCRIPTION
…ions are not called in seafile but cause conflicting types error when compile.