### PR TITLE
fix errors while building with `--with-gpl-crypto=yes` opt

### DIFF
--- a/common/seafile-crypt.c
+++ b/common/seafile-crypt.c
@@ -120,7 +120,11 @@ seafile_generate_repo_salt (char *repo_salt)
 {
     unsigned char repo_salt_bin[32];
 
+#ifdef USE_GPL_CRYPTO
+    int rc = gnutls_rnd (GNUTLS_RND_RANDOM, repo_salt_bin, sizeof(repo_salt_bin));
+#else
     int rc = RAND_bytes (repo_salt_bin, sizeof(repo_salt_bin));
+#endif
     if (rc != 1) {
         seaf_warning ("Failed to generate salt for repo encryption.\n");
         return -1;


### PR DESCRIPTION
```bash
./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --docdir=/usr/share/doc/seafile-7.0.1-r3 --htmldir=/usr/share/doc/seafile-7.0.1-r3/html --with-sysroot=/ --libdir=/usr/lib64 --with-gpl-crypto=yes
configure: loading site script /usr/share/config.site
checking for a BSD-compatible install... /usr/lib/portage/python3.6/ebuild-helpers/xattr/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking build system type... x86_64-pc-linux-gnu
checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... none needed
checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of x86_64-pc-linux-gnu-gcc... none
checking for an ANSI C-conforming const... yes
checking whether make sets $(MAKE)... (cached) yes
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/x86_64-pc-linux-gnu-nm -B
checking the name lister (/usr/bin/x86_64-pc-linux-gnu-nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-pc-linux-gnu/bin/ld option to reload object files... -r
checking for x86_64-pc-linux-gnu-objdump... x86_64-pc-linux-gnu-objdump
checking how to recognize dependent libraries... pass_all
checking for x86_64-pc-linux-gnu-dlltool... no
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for x86_64-pc-linux-gnu-ar... x86_64-pc-linux-gnu-ar
checking for archiver @FILE support... @
checking for x86_64-pc-linux-gnu-strip... x86_64-pc-linux-gnu-strip
checking for x86_64-pc-linux-gnu-ranlib... x86_64-pc-linux-gnu-ranlib
checking command to parse /usr/bin/x86_64-pc-linux-gnu-nm -B output from x86_64-pc-linux-gnu-gcc object... ok
checking for sysroot... /
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for x86_64-pc-linux-gnu-mt... no
checking for mt... mt
checking if mt is a manifest tool... no
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if x86_64-pc-linux-gnu-gcc supports -fno-rtti -fno-exceptions... no
checking for x86_64-pc-linux-gnu-gcc option to produce PIC... -fPIC -DPIC
checking if x86_64-pc-linux-gnu-gcc PIC flag -fPIC -DPIC works... yes
checking if x86_64-pc-linux-gnu-gcc static flag -static works... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... (cached) yes
checking whether the x86_64-pc-linux-gnu-gcc linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for valac... /usr/bin/valac-0.42
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking for WIN32... no
checking for Mac... no
checking for Linux... compile in linux
checking for uuid_generate in -luuid... yes
found library uuid
checking for pthread_create in -lpthread... yes
found library pthread
checking for sqlite3_open in -lsqlite3... yes
found library sqlite3
checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/x86_64-pc-linux-gnu-pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for glib-2.0 >= 2.16.0... yes
checking for gobject-2.0 >= 2.16.0... yes
checking for libsearpc >= 1.0... yes
checking for jansson >= 2.2.1... yes
checking for libevent >= 2.0... yes
checking for zlib >= 1.2.0... yes
checking for libcurl >= 7.17... yes
checking whether /usr/bin/python2.7 version is >= 2.6... yes
checking for /usr/bin/python2.7 version... 2.7
checking for /usr/bin/python2.7 platform... linux2
checking for /usr/bin/python2.7 script directory... ${prefix}/lib64/python2.7/site-packages
checking for /usr/bin/python2.7 extension module directory... ${exec_prefix}/lib64/python2.7/site-packages
checking for gnutls >= 3.3.0... yes
checking for nettle... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating include/Makefile
config.status: creating lib/Makefile
config.status: creating lib/libseafile.pc
config.status: creating common/Makefile
config.status: creating common/cdc/Makefile
config.status: creating common/index/Makefile
config.status: creating daemon/Makefile
config.status: creating app/Makefile
config.status: creating doc/Makefile
config.status: creating python/Makefile
config.status: creating python/seafile/Makefile
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
>>> Source configured.
>>> Compiling source in /var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1 ...
make -j5 
make  all-recursive
make[1]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1'
Making all in include
make[2]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/include'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/include'
Making all in lib
make[2]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/lib'
rm -f repo.c task.c
rm -f seafile-object.h
/usr/bin/valac-0.42 --pkg posix repo.vala task.vala -C -H seafile-object.h
/usr/bin/valac-0.42 -C --pkg posix repo.vala task.vala
[libsearpc]: generating rpc header files
/usr/bin/python2.7 `which searpc-codegen.py` ../lib/rpc_table.py
loaded func_table from /var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/lib/rpc_table.py
[libsearpc]: done
make  all-am
make[3]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/lib'
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o repo.lo repo.c
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o task.lo task.c
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o seafile-rpc-wrapper.lo seafile-rpc-wrapper.c
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o net.lo net.c
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o utils.lo utils.c
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c repo.c  -fPIC -DPIC -o .libs/repo.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c seafile-rpc-wrapper.c  -fPIC -DPIC -o .libs/seafile-rpc-wrapper.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c net.c  -fPIC -DPIC -o .libs/net.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c task.c  -fPIC -DPIC -o .libs/task.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c utils.c  -fPIC -DPIC -o .libs/utils.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c seafile-rpc-wrapper.c -o seafile-rpc-wrapper.o >/dev/null 2>&1
utils.c: In function ‘ccnet_expand_path’:
utils.c:1151:9: warning: ignoring return value of ‘getcwd’, declared with attribute warn_unused_result [-Wunused-result]
         getcwd (new_path, SEAF_PATH_MAX);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c net.c -o net.o >/dev/null 2>&1
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c task.c -o task.o >/dev/null 2>&1
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall   -O2 -pipe -c -o db.lo db.c
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c db.c  -fPIC -DPIC -o .libs/db.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c utils.c -o utils.o >/dev/null 2>&1
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c db.c -o db.o >/dev/null 2>&1
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I../include -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c repo.c -o repo.o >/dev/null 2>&1
/bin/sh ../libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc  -O2 -pipe -no-undefined -Wl,-O1 -Wl,--as-needed -o libseafile.la -rpath /usr/lib64 repo.lo task.lo seafile-rpc-wrapper.lo -lglib-2.0  -lgobject-2.0 -lglib-2.0 -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -ljansson 
/bin/sh ../libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc  -O2 -pipe -no-undefined -Wl,-O1 -Wl,--as-needed -o libseafile_common.la  repo.lo task.lo net.lo utils.lo db.lo -lglib-2.0  -lgobject-2.0 -lglib-2.0 -luuid   -lsqlite3 -levent -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -ljansson -lz 
libtool: link: x86_64-pc-linux-gnu-gcc -shared  -fPIC -DPIC  .libs/repo.o .libs/task.o .libs/seafile-rpc-wrapper.o   -Wl,--as-needed -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -ljansson  -O2 -Wl,-O1   -Wl,-soname -Wl,libseafile.so.0 -o .libs/libseafile.so.0.0.0
libtool: link: x86_64-pc-linux-gnu-ar cru .libs/libseafile_common.a .libs/repo.o .libs/task.o .libs/net.o .libs/utils.o .libs/db.o 
libtool: link: x86_64-pc-linux-gnu-ranlib .libs/libseafile_common.a
libtool: link: ( cd ".libs" && rm -f "libseafile_common.la" && ln -s "../libseafile_common.la" "libseafile_common.la" )
libtool: link: (cd ".libs" && rm -f "libseafile.so.0" && ln -s "libseafile.so.0.0.0" "libseafile.so.0")
libtool: link: (cd ".libs" && rm -f "libseafile.so" && ln -s "libseafile.so.0.0.0" "libseafile.so")
libtool: link: x86_64-pc-linux-gnu-ar cru .libs/libseafile.a  repo.o task.o seafile-rpc-wrapper.o
libtool: link: x86_64-pc-linux-gnu-ranlib .libs/libseafile.a
libtool: link: ( cd ".libs" && rm -f "libseafile.la" && ln -s "../libseafile.la" "libseafile.la" )
make[3]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/lib'
make[2]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/lib'
Making all in common
make[2]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common'
Making all in cdc
make[3]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/cdc'
/bin/sh ../../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../..    -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include  -O2 -pipe -c -o cdc.lo cdc.c
/bin/sh ../../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../..    -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include  -O2 -pipe -c -o rabin-checksum.lo rabin-checksum.c
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c cdc.c  -fPIC -DPIC -o .libs/cdc.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c rabin-checksum.c  -fPIC -DPIC -o .libs/rabin-checksum.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c rabin-checksum.c -o rabin-checksum.o >/dev/null 2>&1
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c cdc.c -o cdc.o >/dev/null 2>&1
/bin/sh ../../libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc -I../../common -I../../lib -Wall -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include  -O2 -pipe -Wl,-z -Wl,defs -Wl,-O1 -Wl,--as-needed -o libcdc.la  cdc.lo rabin-checksum.lo -lglib-2.0 ../../lib/libseafile_common.la 
libtool: link: (cd .libs/libcdc.lax/libseafile_common.a && x86_64-pc-linux-gnu-ar x "/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/cdc/../../lib/.libs/libseafile_common.a")
libtool: link: x86_64-pc-linux-gnu-ar cru .libs/libcdc.a .libs/cdc.o .libs/rabin-checksum.o   .libs/libcdc.lax/libseafile_common.a/db.o .libs/libcdc.lax/libseafile_common.a/net.o .libs/libcdc.lax/libseafile_common.a/repo.o .libs/libcdc.lax/libseafile_common.a/task.o .libs/libcdc.lax/libseafile_common.a/utils.o 
libtool: link: x86_64-pc-linux-gnu-ranlib .libs/libcdc.a
libtool: link: rm -fr .libs/libcdc.lax
libtool: link: ( cd ".libs" && rm -f "libcdc.la" && ln -s "../libcdc.la" "libcdc.la" )
make[3]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/cdc'
Making all in index
make[3]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/index'
/bin/sh ../../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../..  -Wall -I../../common -I../../lib   -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c -o libindex_la-index.lo `test -f 'index.c' || echo './'`index.c
/bin/sh ../../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../..  -Wall -I../../common -I../../lib   -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c -o libindex_la-cache-tree.lo `test -f 'cache-tree.c' || echo './'`cache-tree.c
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -Wall -I../../common -I../../lib -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c index.c  -fPIC -DPIC -o .libs/libindex_la-index.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -Wall -I../../common -I../../lib -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c cache-tree.c  -fPIC -DPIC -o .libs/libindex_la-cache-tree.o
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -Wall -I../../common -I../../lib -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c cache-tree.c -o libindex_la-cache-tree.o >/dev/null 2>&1
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../.. -Wall -I../../common -I../../lib -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -c index.c -o libindex_la-index.o >/dev/null 2>&1
/bin/sh ../../libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -O2 -pipe -Wl,-z -Wl,defs -Wl,-O1 -Wl,--as-needed -o libindex.la  libindex_la-index.lo libindex_la-cache-tree.lo -lglib-2.0 ../../lib/libseafile_common.la 
libtool: link: (cd .libs/libindex.lax/libseafile_common.a && x86_64-pc-linux-gnu-ar x "/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/index/../../lib/.libs/libseafile_common.a")
libtool: link: x86_64-pc-linux-gnu-ar cru .libs/libindex.a .libs/libindex_la-index.o .libs/libindex_la-cache-tree.o   .libs/libindex.lax/libseafile_common.a/db.o .libs/libindex.lax/libseafile_common.a/net.o .libs/libindex.lax/libseafile_common.a/repo.o .libs/libindex.lax/libseafile_common.a/task.o .libs/libindex.lax/libseafile_common.a/utils.o 
libtool: link: x86_64-pc-linux-gnu-ranlib .libs/libindex.a
libtool: link: rm -fr .libs/libindex.lax
libtool: link: ( cd ".libs" && rm -f "libindex.la" && ln -s "../libindex.la" "libindex.la" )
make[3]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common/index'
make[3]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common'
make[2]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/common'
Making all in daemon
make[2]: Entering directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/daemon'
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o seaf-daemon.o seaf-daemon.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o job-mgr.o job-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o timer.o timer.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o cevent.o cevent.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o http-tx-mgr.o http-tx-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o vc-utils.o vc-utils.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o sync-mgr.o sync-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o seafile-session.o seafile-session.c
seaf-daemon.c: In function ‘main’:
seaf-daemon.c:446:9: warning: ignoring return value of ‘daemon’, declared with attribute warn_unused_result [-Wunused-result]
         daemon (1, 0);
         ^~~~~~~~~~~~~
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o seafile-crypt.o `test -f '../common/seafile-crypt.c' || echo './'`../common/seafile-crypt.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o diff-simple.o `test -f '../common/diff-simple.c' || echo './'`../common/diff-simple.c
../common/seafile-crypt.c: In function ‘seafile_generate_repo_salt’:
../common/seafile-crypt.c:123:14: warning: implicit declaration of function ‘RAND_bytes’; did you mean ‘RAND_MAX’? [-Wimplicit-function-declaration]
     int rc = RAND_bytes (repo_salt_bin, sizeof(repo_salt_bin));
              ^~~~~~~~~~
              RAND_MAX
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o wt-monitor.o wt-monitor.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o wt-monitor-linux.o wt-monitor-linux.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o wt-monitor-structs.o wt-monitor-structs.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o clone-mgr.o clone-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o seafile-config.o seafile-config.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o branch-mgr.o `test -f '../common/branch-mgr.c' || echo './'`../common/branch-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o fs-mgr.o `test -f '../common/fs-mgr.c' || echo './'`../common/fs-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o repo-mgr.o repo-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o commit-mgr.o `test -f '../common/commit-mgr.c' || echo './'`../common/commit-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o log.o `test -f '../common/log.c' || echo './'`../common/log.c
repo-mgr.c: In function ‘delete_worktree_dir_recursive’:
repo-mgr.c:5102:14: warning: variable ‘builtin_ignored’ set but not used [-Wunused-but-set-variable]
     gboolean builtin_ignored = FALSE;
              ^~~~~~~~~~~~~~~
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o rpc-service.o `test -f '../common/rpc-service.c' || echo './'`../common/rpc-service.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o vc-common.o `test -f '../common/vc-common.c' || echo './'`../common/vc-common.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o obj-store.o `test -f '../common/obj-store.c' || echo './'`../common/obj-store.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o obj-backend-fs.o `test -f '../common/obj-backend-fs.c' || echo './'`../common/obj-backend-fs.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o block-mgr.o `test -f '../common/block-mgr.c' || echo './'`../common/block-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o block-backend.o `test -f '../common/block-backend.c' || echo './'`../common/block-backend.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o block-backend-fs.o `test -f '../common/block-backend-fs.c' || echo './'`../common/block-backend-fs.c
../common/obj-backend-fs.c: In function ‘obj_backend_fs_write’:
../common/obj-backend-fs.c:229:43: warning: ‘.XXXXXX’ directive output may be truncated writing 7 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
     snprintf (tmp_path, SEAF_PATH_MAX, "%s.XXXXXX", path);
                                           ^~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ../common/common.h:17,
                 from ../common/obj-backend-fs.c:5:
/usr/include/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 8 and 4103 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o mq-mgr.o `test -f '../common/mq-mgr.c' || echo './'`../common/mq-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o curl-init.o `test -f '../common/curl-init.c' || echo './'`../common/curl-init.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o sync-status-tree.o sync-status-tree.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o filelock-mgr.o filelock-mgr.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o set-perm.o set-perm.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I..    -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -c -o change-set.o change-set.c
/bin/sh ../libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\""/usr/share/seafile"\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe  -Wl,-O1 -Wl,--as-needed -o seaf-daemon seaf-daemon.o job-mgr.o timer.o cevent.o http-tx-mgr.o vc-utils.o sync-mgr.o seafile-session.o seafile-crypt.o diff-simple.o wt-monitor.o wt-monitor-linux.o wt-monitor-structs.o clone-mgr.o seafile-config.o branch-mgr.o fs-mgr.o repo-mgr.o commit-mgr.o log.o rpc-service.o vc-common.o obj-store.o obj-backend-fs.o block-mgr.o block-backend.o block-backend-fs.o mq-mgr.o curl-init.o sync-status-tree.o filelock-mgr.o set-perm.o change-set.o ../lib/libseafile_common.la -lglib-2.0  -lgobject-2.0 -lglib-2.0  -lgnutls -lnettle -luuid -lsqlite3 -levent ../common/cdc/libcdc.la ../common/index/libindex.la -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -ljansson -ljansson  -lz -lcurl  
libtool: link: x86_64-pc-linux-gnu-gcc -DPKGDATADIR=\"/usr/share/seafile\" -DPACKAGE_DATA_DIR=\"/usr/share/seafile\" -DSEAFILE_CLIENT -I../include -I../lib -I../lib -I../common -pthread -I/usr/include/searpc -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -Wall -O2 -pipe -Wl,-O1 -o seaf-daemon seaf-daemon.o job-mgr.o timer.o cevent.o http-tx-mgr.o vc-utils.o sync-mgr.o seafile-session.o seafile-crypt.o diff-simple.o wt-monitor.o wt-monitor-linux.o wt-monitor-structs.o clone-mgr.o seafile-config.o branch-mgr.o fs-mgr.o repo-mgr.o commit-mgr.o log.o rpc-service.o vc-common.o obj-store.o obj-backend-fs.o block-mgr.o block-backend.o block-backend-fs.o mq-mgr.o curl-init.o sync-status-tree.o filelock-mgr.o set-perm.o change-set.o  -Wl,--as-needed ../lib/.libs/libseafile_common.a -lgnutls -lnettle ../common/cdc/.libs/libcdc.a ../common/index/.libs/libindex.a -luuid -lsqlite3 -levent -lsearpc -lgio-2.0 -lgobject-2.0 -lglib-2.0 -ljansson -lz -lcurl -pthread
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: seafile-crypt.o: undefined reference to symbol 'RAND_bytes'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libcrypto.so.1.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:556: seaf-daemon] Error 1
make[2]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1/daemon'
make[1]: *** [Makefile:444: all-recursive] Error 1
make[1]: Leaving directory '/var/tmp/portage/net-misc/seafile-7.0.1-r3/work/seafile-7.0.1'
make: *** [Makefile:376: all] Error 2
```