### PR TITLE
Fix build instruction link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,7 +64,7 @@ For this reason, the sync client daemon repository is still the "front page" for
 Build and Run
 =============
 
-See <http://manual.seafile.com/build_seafile/server.html>
+See <https://download.seafile.com/published/seafile-manual/build_seafile/server.md>
 
 Bug and Feature Request Reports
 ===============================


### PR DESCRIPTION
Imho it would still be preferable to have the build instructions within the repository, so they always match the commit when checking out an older version.