### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: c
 dist: Xenial
+arch:
+ - amd64
+ - ppc64le
 compiler: gcc
 os: linux
 install:


### PR DESCRIPTION
This PR adds CI support for ppc64le architecture. Continuously building and testing on this architecture along with intel will ensure that we detect /fix any issues earlier and are always up-to-date.