### PR TITLE
Reading WatchCommand  got error

### DIFF
--- a/daemon/wt-monitor-win32.c
+++ b/daemon/wt-monitor-win32.c
@@ -264,7 +264,7 @@ start_watch_cmd_pipe (SeafWTMonitor *monitor, OVERLAPPED *ol_in)
 
     HANDLE hPipe = (HANDLE)monitor->cmd_pipe[0];
 
-    void *p = &priv->cmd + priv->cmd_bytes_read;
+    char *p = (char*)(&priv->cmd) + priv->cmd_bytes_read;
     int to_read = sizeof(WatchCommand) - priv->cmd_bytes_read;
 
     BOOL sts = ReadFile


### PR DESCRIPTION
WatchCommand is sent as bytes stream, so is read also as bytes steam. So (void* p = &priv->cmd +  priv->cmd_bytes_read ) is wrong, it should be char *p = (char*)(&priv->cmd) + priv->cmd_bytes_read.