### PR TITLE
Get token from "account" section of user configuration file (if available)

### DIFF
--- a/app/seaf-cli
+++ b/app/seaf-cli
@@ -308,6 +308,38 @@ def get_repo_download_info(url, token):
     repo_info = urlopen(url, headers=headers)
     return json.loads(repo_info.decode('utf8'))
 
+def get_value_from_user_config(args, section, key):
+    user_config = args.C
+    if not user_config:
+        user_config = DEFAULT_USER_CONF_DIR
+    else:
+        user_config = abspath(user_config)
+    if _user_config_valid(user_config):
+        try:
+            from configparser import ConfigParser
+            from configparser import NoOptionError
+        except ImportError:
+            from ConfigParser import ConfigParser
+            from ConfigParser import NoOptionError
+
+        cfg = ConfigParser()
+        cfg.read(user_config)
+        if len(cfg.sections()) < 1 or cfg.sections()[0] != 'account':
+            return None
+        try:
+            token = cfg.get(section, key)
+            return token
+        except NoOptionError:
+            return None
+    else:
+        return None
+
+def get_token_from_args_or_config(args):
+    if args.token:
+        return args.token
+    else:
+        return get_value_from_user_config(args, 'account', 'token')
+
 def seaf_init(args):
     ''' Initialize config directories'''
 
@@ -401,14 +433,8 @@ def seaf_list_remote(args):
 
     conf_dir = _conf_dir(args)
 
-    server_from_config, user_from_config = None, None
-    user_config_dir = args.C
-    if not user_config_dir:
-        user_config_dir = DEFAULT_USER_CONF_DIR
-    else:
-        user_config_dir = abspath(user_config_dir)
-    if _user_config_valid(user_config_dir):
-        server_from_config, user_from_config = _parse_user_config(user_config_dir)    
+    server_from_config = get_value_from_user_config(args, 'account', 'server')
+    user_from_config = get_value_from_user_config(args, 'account', 'user')
 
     url = args.server        
     if not url and server_from_config:
@@ -425,7 +451,7 @@ def seaf_list_remote(args):
     if not username:
         username = input("Enter username: ")
 
-    token = args.token
+    token = get_token_from_args_or_config(args)
     password = None
     tfa = args.tfa
     if not token:
@@ -478,14 +504,8 @@ def seaf_download(args):
         print("Library id is required")
         sys.exit(1)
 
-    server_from_config, user_from_config = None, None        
-    user_config_dir = args.C
-    if not user_config_dir:
-        user_config_dir = DEFAULT_USER_CONF_DIR
-    else:
-        user_config_dir = abspath(user_config_dir)
-    if _user_config_valid(user_config_dir):
-        server_from_config, user_from_config = _parse_user_config(user_config_dir)
+    server_from_config = get_value_from_user_config(args, 'account', 'server')
+    user_from_config = get_value_from_user_config(args, 'account', 'user')
 
     url = args.server
     if not url and server_from_config:
@@ -506,7 +526,7 @@ def seaf_download(args):
         username = user_from_config
     if not username:
         username = input("Enter username: ")
-    token = args.token
+    token = get_token_from_args_or_config(args)
     password = None
     tfa = args.tfa
     if not token:
@@ -571,14 +591,8 @@ def seaf_download_by_name(args):
         print("Library name is required")
         sys.exit(1)
 
-    server_from_config, user_from_config = None, None
-    user_config_dir = args.C
-    if not user_config_dir:
-        user_config_dir = DEFAULT_USER_CONF_DIR
-    else:
-        user_config_dir = abspath(user_config_dir)
-    if _user_config_valid(user_config_dir):
-        server_from_config, user_from_config = _parse_user_config(user_config_dir)        
+    server_from_config = get_value_from_user_config(args, 'account', 'server')
+    user_from_config = get_value_from_user_config(args, 'account', 'user')
 
     url = args.server        
     if not url and server_from_config:
@@ -596,7 +610,7 @@ def seaf_download_by_name(args):
         username = input("Enter username: ")
         args.username = username
 
-    token = args.token
+    token = get_token_from_args_or_config(args)
     password = None
     tfa = args.tfa
     if not token:
@@ -631,14 +645,8 @@ def seaf_sync(args):
         print("Library id is required")
         sys.exit(1)
 
-    server_from_config, user_from_config = None, None
-    user_config_dir = args.C
-    if not user_config_dir:
-        user_config_dir = DEFAULT_USER_CONF_DIR
-    else:
-        user_config_dir = abspath(user_config_dir)
-    if _user_config_valid(user_config_dir):
-        server_from_config, user_from_config = _parse_user_config(user_config_dir)
+    server_from_config = get_value_from_user_config(args, 'account', 'server')
+    user_from_config = get_value_from_user_config(args, 'account', 'user')
 
     url = args.server
     if not url and server_from_config:
@@ -666,7 +674,7 @@ def seaf_sync(args):
         username = input("Enter username: ")
 
     password = None
-    token = args.token
+    token = get_token_from_args_or_config(args)
     tfa = args.tfa
     if not token:
         password = args.password
@@ -847,14 +855,8 @@ def seaf_create(args):
     '''Create a library'''
     conf_dir = _conf_dir(args)
 
-    server_from_config, user_from_config = None, None
-    user_config_dir = args.C
-    if not user_config_dir:
-        user_config_dir = DEFAULT_USER_CONF_DIR
-    else:
-        user_config_dir = abspath(user_config_dir)
-    if _user_config_valid(user_config_dir):
-        server_from_config, user_from_config = _parse_user_config(user_config_dir)    
+    server_from_config = get_value_from_user_config(args, 'account', 'server')
+    user_from_config = get_value_from_user_config(args, 'account', 'user')
 
     # check username and password
     username = args.username
@@ -870,7 +872,7 @@ def seaf_create(args):
         print("Seafile server url need to be presented")
         sys.exit(1)
 
-    token = args.token
+    token = get_token_from_args_or_config(args)
     password = None
     tfa = args.tfa
     if not token:


### PR DESCRIPTION
This adds code to read the value of "token" for authentication from the user configuration file.
It also moves some repeated code for reading the user configuration file in general to a function (this renders `_parse_user_config` obsolete, but I did not remove it, in case you don't like my changes).

Essentially this means that with a user configuration file in e.g. `~/.seaf-cli/seafile.ini` which looks like this
```
[account]
server = https://seafile.example.com
user = some.user@example.com
token = web-api-auth-token-value-from-your-profile
```
one can use commands without giving server, user and token on the command-line. E.g.: 
`seaf-cli list-remote -C ~/.seaf-cli/seafile.ini`

Fixes a [seafile-cli security problem](https://forum.seafile.com/t/17460)