### PR TITLE
GCC 14.1: Fix incompatible pointer type

### DIFF
--- a/daemon/repo-mgr.c
+++ b/daemon/repo-mgr.c
@@ -4885,7 +4885,7 @@ out:
 // Since file creation is asynchronous, the file may not have been created locally at the time of checking for case conflicts, 
 // so an additional check for the name of the file being created is required.
 static gboolean
-is_adding_files_case_conflict (GList **adding_files, const char *name, const char **conflict_path)
+is_adding_files_case_conflict (GList **adding_files, const char *name, char **conflict_path)
 {
     GList *ptr;
     SeafStat st;


### PR DESCRIPTION
In this context `conflict_path` must be mutable.

```
#12 23.82 repo-mgr.c:4898:46: error: passing argument 3 of ‘check_case_conflict’ from incompatible pointer type [-Wi
ncompatible-pointer-types]
#12 23.82  4898 |         if (check_case_conflict (path, name, conflict_path)){
#12 23.82       |                                              ^~~~~~~~~~~~~
#12 23.82       |                                              |
#12 23.82       |                                              const char **
#12 23.82 repo-mgr.c:4853:67: note: expected ‘char **’ but argument is of type ‘const char **’
#12 23.82  4853 | check_case_conflict (const char *path1, const char *path2, char **conflict_path)
#12 23.82       |                                                            ~~~~~~~^~~~~~~~~~~~~
...
#12 23.82 repo-mgr.c:4946:63: error: passing argument 3 of ‘is_adding_files_case_conflict’ from incompatible pointer type [-Wincompatible-pointer-types]
#12 23.82  4946 |         is_adding_files_case_conflict(adding_files, de->name, &conflict_path))) {
#12 23.82       |                                                               ^~~~~~~~~~~~~~
#12 23.82       |                                                               |
#12 23.82       |                                                               char **
#12 23.83 repo-mgr.c:4888:85: note: expected ‘const char **’ but argument is of type ‘char **’
#12 23.83  4888 | is_adding_files_case_conflict (GList **adding_files, const char *name, const char **conflict_path)
```

#2774 