### PR TITLE
Fix sync on openSUSE

### DIFF
--- a/daemon/http-tx-mgr.c
+++ b/daemon/http-tx-mgr.c
@@ -506,6 +506,7 @@ char *ca_paths[] = {
     "/usr/share/ssl/certs/ca-bundle.crt",
     "/usr/local/share/certs/ca-root-nss.crt",
     "/etc/ssl/cert.pem",
+    "/etc/ssl/ca-bundle.pem",
 };
 
 static void


### PR DESCRIPTION
This path is used for trust on openSUSE, and without it, the client fails to sync with HTTPS servers.