### PR TITLE
Fix invalid memory access

### DIFF
--- a/daemon/wt-monitor-linux.c
+++ b/daemon/wt-monitor-linux.c
@@ -338,11 +338,9 @@ process_one_event (int in_fd,
     /* if (handle_consecutive_duplicate_event (info, event)) */
     /*     add_to_queue = FALSE; */
 
-    if (event->len == 0)
-    {
+    if (event->len == 0) {
         filename = g_strdup (parent);
-    } else
-    {
+    } else {
         filename = g_build_filename (parent, event->name, NULL);
     }
 


### PR DESCRIPTION
According to man7, the len field of inotify_event indicates the length of the name field, including the terminating '\0'.
In some cases, len can be zero (for example, directory IN_ATTRIB events), but man7 does not explicitly state that the name pointer is NULL in this situation.
During testing, we observed that when len == 0, the value of name may be an invalid (dangling) pointer.
Accessing name without checking len can therefore lead to illegal memory access and unpredictable behavior.