### PR TITLE
Add check to silence "Couldn’t prepare query"

### DIFF
--- a/daemon/http-tx-mgr.c
+++ b/daemon/http-tx-mgr.c
@@ -600,6 +600,13 @@ load_certs_from_db (X509_STORE *store)
         goto out;
     }
 
+    sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Certs';";
+
+    if (!sqlite_check_for_existence (db, sql)) {
+        ret = -1;
+        goto out;
+    }
+
     sql = "SELECT cert FROM Certs;";
 
     if (sqlite_foreach_selected_row (db, sql, load_certs, store) < 0) {


### PR DESCRIPTION
The current `seafile-daemon`, in certain circumstances, logs a repetitive warning
```
Couldn't prepare query, error:1->'no such table: Certs'
```
in `.ccnet/logs/seafile.log` about once per minute per repository.

This change adds a check to prevent that warning.

See https://forum.seafile.com/t/couldnt-prepare-query-error-1-no-such-table-certs