### PR TITLE
Modified app/seaf-cli to make the infinite loop in AppImages unnecessary

### DIFF
--- a/app/seaf-cli
+++ b/app/seaf-cli
@@ -226,7 +226,8 @@ def run_argv(argv, cwd=None, env=None, suppress_stdout=False, suppress_stderr=Fa
                                 cwd=cwd,
                                 stdout=stdout,
                                 stderr=stderr,
-                                env=env)
+                                env=env,
+                                close_fds=False)
         return proc.wait()
 
 def get_env():


### PR DESCRIPTION
The proposed change (just a one liner) makes it unnecessary to perform an infinite loop, that is currently (v. 9.0.18) present in the `AppRun` script of the official AppImages of the client. This allows for cleaner code, and potentially avoids a rare bug if multiple copies of the Seafile daemon  run on the same system (under different users).

See [this forum thread.](https://forum.seafile.com/t/bug-seafile-cli-appimage-9-0-16-spawns-persistent-processes-and-leaves-fuse-mounts-after-start-stop-cycles) for details.